### PR TITLE
Async load text encoder

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -1465,6 +1465,7 @@ def worker():
     while True:
         time.sleep(0.01)
         if len(async_tasks) > 0:
+            pipeline.wait_text_encoder_ready()
             task = async_tasks.pop(0)
 
             try:


### PR DESCRIPTION
## Summary
- load text encoder models on a background thread
- synchronize loading across tasks
- wait in async worker until text encoder is ready before processing a new job

## Testing
- `python - <<'PY'
import sys, unittest
sys.argv = ['']
from tests import test_extra_utils, test_utils
suite = unittest.TestSuite()
suite.addTest(unittest.defaultTestLoader.loadTestsFromModule(test_extra_utils))
suite.addTest(unittest.defaultTestLoader.loadTestsFromModule(test_utils))
runner = unittest.TextTestRunner()
result = runner.run(suite)
exit(not result.wasSuccessful())
PY`

------
https://chatgpt.com/codex/tasks/task_e_684905719d14832bbe6077689eea0f62