### PR TITLE
Fix prompt expansion crash

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -1067,7 +1067,6 @@ def worker():
         return current_task_id, done_steps_inpainting, done_steps_upscaling, img, exception_result
 
     @torch.no_grad()
-    @torch.inference_mode()
     def handler(async_task: AsyncTask):
         preparation_start_time = time.perf_counter()
         async_task.processing = True


### PR DESCRIPTION
## Summary
- avoid using `torch.inference_mode()` in async worker handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68492e52cbd0832bbf6f68a0855977fc