### PR TITLE
Fix inference tensor error for text expansion

### DIFF
--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -290,7 +290,9 @@ def refresh_everything(refiner_model_name, base_model_name, loras,
     final_refiner_vae = model_refiner.vae
 
     if final_expansion is None:
-        final_expansion = FooocusExpansion()
+        # ensure expansion model parameters are created outside of inference mode
+        with torch.inference_mode(False):
+            final_expansion = FooocusExpansion()
 
     prepare_text_encoder(async_call=True)
     clear_all_caches()


### PR DESCRIPTION
## Summary
- prevent GPT2 expansion model from loading under `inference_mode`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492f5d3254832b97c40a8fb6465bc7