### PR TITLE
Add Forge-style prompt styles

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -3,6 +3,7 @@ import threading
 from extras.inpaint_mask import generate_mask_from_image, SAMOptions
 from modules.patch import PatchSettings, patch_settings, patch_all
 import modules.config
+import shared
 
 patch_all()
 
@@ -30,6 +31,13 @@ class AsyncTask:
         self.prompt = args.pop()
         self.negative_prompt = args.pop()
         self.style_selections = args.pop()
+        self.csv_styles = args.pop()
+        if self.csv_styles is None:
+            self.csv_styles = []
+        elif isinstance(self.csv_styles, str):
+            self.csv_styles = [self.csv_styles]
+        self.prompt = shared.prompt_styles.apply_styles_to_prompt(self.prompt, self.csv_styles)
+        self.negative_prompt = shared.prompt_styles.apply_negative_styles_to_prompt(self.negative_prompt, self.csv_styles)
 
         self.performance_selection = Performance(args.pop())
         self.steps = self.performance_selection.steps()

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -1,0 +1,8 @@
+from .prompt_style_system import (
+    PromptStyle,
+    StyleDatabase,
+    merge_prompts,
+    apply_styles_to_prompt,
+    apply_negative_styles_to_prompt,
+    extract_original_prompts,
+)

--- a/shared.py
+++ b/shared.py
@@ -1,1 +1,2 @@
 gradio_root = None
+prompt_styles = None


### PR DESCRIPTION
## Summary
- initialize global `prompt_styles` via new `modules/styles` wrapper
- update webui to use shared `prompt_styles`
- implement style editing callbacks and clear selection after apply
- pass selected CSV styles to AsyncTask and merge before generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c8107888832b925c4e941102727a