### PR TITLE
Fix custom style handling

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -3,6 +3,7 @@ import threading
 from extras.inpaint_mask import generate_mask_from_image, SAMOptions
 from modules.patch import PatchSettings, patch_settings, patch_all
 import modules.config
+import modules.sdxl_styles
 import shared
 
 patch_all()
@@ -36,6 +37,16 @@ class AsyncTask:
             self.csv_styles = []
         elif isinstance(self.csv_styles, str):
             self.csv_styles = [self.csv_styles]
+
+        filtered_style_selections = []
+        for style in list(self.style_selections):
+            if style in modules.sdxl_styles.legal_style_names:
+                filtered_style_selections.append(style)
+            else:
+                self.csv_styles.append(style)
+
+        self.style_selections = filtered_style_selections
+
         self.prompt = shared.prompt_styles.apply_styles_to_prompt(self.prompt, self.csv_styles)
         self.negative_prompt = shared.prompt_styles.apply_negative_styles_to_prompt(self.negative_prompt, self.csv_styles)
 


### PR DESCRIPTION
## Summary
- ensure style selections not recognized by built-in SDXL list are applied as CSV styles
- import `modules.sdxl_styles` in async worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849eed2a304832b86a7986bc57df8e6