### PR TITLE
Adjust style edit button layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -350,3 +350,11 @@ div:has(> #positive_prompt) {
 #inpaint_brush_color input[type=color]{
   background: none;
 }
+
+/* Make style edit buttons square and free space for the dropdown */
+[id$="_styles_edit_button"] button {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  min-width: 30px;
+}

--- a/modules/ui_components.py
+++ b/modules/ui_components.py
@@ -1,6 +1,12 @@
 import gradio as gr
 
 
-def ToolButton(value, elem_id=None, tooltip=None):
+def ToolButton(value, elem_id=None, tooltip=None, **kwargs):
     """Simple button used as a small tool icon."""
-    return gr.Button(value=value, elem_id=elem_id, tooltip=tooltip, variant="secondary")
+    return gr.Button(
+        value=value,
+        elem_id=elem_id,
+        tooltip=tooltip,
+        variant="secondary",
+        **kwargs,
+    )

--- a/modules/ui_prompt_styles.py
+++ b/modules/ui_prompt_styles.py
@@ -68,11 +68,13 @@ class UiPromptStyles:
                 value=[],
                 multiselect=True,
                 tooltip="Styles",
+                scale=1,
             )
             edit_button = ui_components.ToolButton(
                 value=styles_edit_symbol,
                 elem_id=f"{tabname}_styles_edit_button",
                 tooltip="Edit styles",
+                scale=0,
             )
 
         with gr.Box(elem_id=f"{tabname}_styles_dialog", visible=False) as styles_dialog:

--- a/ui_prompt_styles.py
+++ b/ui_prompt_styles.py
@@ -60,8 +60,22 @@ class UiPromptStyles:
         self.main_ui_negative_prompt = main_ui_negative_prompt
 
         with gr.Row(elem_id=f"{tabname}_styles_row"):
-            self.dropdown = gr.Dropdown(label="Styles", show_label=False, elem_id=f"{tabname}_styles", choices=list(shared.prompt_styles.styles), value=[], multiselect=True, tooltip="Styles")
-            edit_button = ui_components.ToolButton(value=styles_edit_symbol, elem_id=f"{tabname}_styles_edit_button", tooltip="Edit styles")
+            self.dropdown = gr.Dropdown(
+                label="Styles",
+                show_label=False,
+                elem_id=f"{tabname}_styles",
+                choices=list(shared.prompt_styles.styles),
+                value=[],
+                multiselect=True,
+                tooltip="Styles",
+                scale=1,
+            )
+            edit_button = ui_components.ToolButton(
+                value=styles_edit_symbol,
+                elem_id=f"{tabname}_styles_edit_button",
+                tooltip="Edit styles",
+                scale=0,
+            )
 
         with gr.Box(elem_id=f"{tabname}_styles_dialog", elem_classes="popup-dialog") as styles_dialog:
             with gr.Row():


### PR DESCRIPTION
## Summary
- allow passing kwargs to `ToolButton`
- make the styles dropdown use most of the row space
- shrink the edit button with CSS for a compact look

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f418110c832ba17205ba0e93904b