### PR TITLE
Update UI layout and seed behaviour

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -124,7 +124,8 @@ div:has(> #positive_prompt) {
 }
 
 .aspect_ratios label input {
-    margin-left: -5px !important;
+    margin-left: 0 !important;
+    margin-right: 4px !important;
 }
 
 /* group titles and separators for aspect ratios */
@@ -387,4 +388,15 @@ div:has(> #positive_prompt) {
   height: 30px;
   padding: 0;
   min-width: 30px;
+}
+
+/* style for seed dice and restore buttons */
+.seed_button {
+  background: #eee !important;
+  border: 1px solid #aaa !important;
+  width: 30px !important;
+  height: 30px !important;
+  padding: 0 !important;
+  min-width: 30px !important;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- show negative prompt above presets
- move aspect ratio options into its own accordion
- keep seed textbox on `-1` when using random seed and add restore button
- style seed buttons
- adjust aspect ratio padding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a16a08078832b84025352f059ac78