### PR TITLE
Implement persistent model and LoRA settings

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -775,6 +775,26 @@ default_aspect_ratio = add_ratio(default_aspect_ratio)
 available_aspect_ratios_labels = [add_ratio(x) for x in available_aspect_ratios]
 
 
+def split_aspect_ratios(ratios):
+    square = []
+    portrait = []
+    landscape = []
+    for r in ratios:
+        w, h = r.split('*')[:2]
+        w, h = int(w), int(h)
+        label = add_ratio(r)
+        if w == h:
+            square.append(label)
+        elif w < h:
+            portrait.append(label)
+        else:
+            landscape.append(label)
+    return square, portrait, landscape
+
+
+aspect_ratio_square_labels, aspect_ratio_portrait_labels, aspect_ratio_landscape_labels = split_aspect_ratios(available_aspect_ratios)
+
+
 # Only write config in the first launch.
 if not os.path.exists(config_path):
     with open(config_path, "w", encoding="utf-8") as json_file:

--- a/webui.py
+++ b/webui.py
@@ -565,16 +565,51 @@ with shared.gradio_root:
                                              value=modules.config.default_prompt_negative)
 
                 with gr.Accordion(label='Aspect Ratios', open=False):
-                    aspect_ratios_selection = gr.Radio(label='Aspect Ratios', show_label=False,
-                                                       choices=modules.config.available_aspect_ratios_labels,
-                                                       value=modules.config.default_aspect_ratio,
-                                                       info='width × height',
-                                                       elem_classes='aspect_ratios')
+                    aspect_ratios_selection_hidden = gr.Radio(choices=modules.config.available_aspect_ratios_labels,
+                                                             value=modules.config.default_aspect_ratio,
+                                                             visible=False,
+                                                             elem_id='aspect_ratio_hidden')
 
-                    aspect_ratios_selection.change(lambda x: modules.config.set_config_value('default_aspect_ratio', x),
-                                                  inputs=aspect_ratios_selection, queue=False, show_progress=False,
+                    gr.HTML('<b>Square</b> <span style="font-size: smaller; color: grey;">width × height</span>')
+                    aspect_ratio_square = gr.Radio(show_label=False,
+                                                   choices=modules.config.aspect_ratio_square_labels,
+                                                   value=modules.config.default_aspect_ratio if modules.config.default_aspect_ratio in modules.config.aspect_ratio_square_labels else None,
+                                                   elem_classes='aspect_ratios')
+
+                    gr.HTML('<b>Portrait</b> <span style="font-size: smaller; color: grey;">width × height</span>')
+                    aspect_ratio_portrait = gr.Radio(show_label=False,
+                                                     choices=modules.config.aspect_ratio_portrait_labels,
+                                                     value=modules.config.default_aspect_ratio if modules.config.default_aspect_ratio in modules.config.aspect_ratio_portrait_labels else None,
+                                                     elem_classes='aspect_ratios')
+
+                    gr.HTML('<b>Landscape</b> <span style="font-size: smaller; color: grey;">width × height</span>')
+                    aspect_ratio_landscape = gr.Radio(show_label=False,
+                                                      choices=modules.config.aspect_ratio_landscape_labels,
+                                                      value=modules.config.default_aspect_ratio if modules.config.default_aspect_ratio in modules.config.aspect_ratio_landscape_labels else None,
+                                                      elem_classes='aspect_ratios')
+
+                    def aspect_ratio_change(v):
+                        modules.config.set_config_value('default_aspect_ratio', v)
+                        return [gr.update(value=v if v in modules.config.aspect_ratio_square_labels else None),
+                                gr.update(value=v if v in modules.config.aspect_ratio_portrait_labels else None),
+                                gr.update(value=v if v in modules.config.aspect_ratio_landscape_labels else None),
+                                v]
+
+                    aspect_ratio_square.change(aspect_ratio_change, inputs=aspect_ratio_square,
+                                               outputs=[aspect_ratio_square, aspect_ratio_portrait, aspect_ratio_landscape, aspect_ratios_selection_hidden],
+                                               queue=False, show_progress=False,
+                                               _js='(x)=>{refresh_aspect_ratios_label(x);}')
+                    aspect_ratio_portrait.change(aspect_ratio_change, inputs=aspect_ratio_portrait,
+                                                 outputs=[aspect_ratio_square, aspect_ratio_portrait, aspect_ratio_landscape, aspect_ratios_selection_hidden],
+                                                 queue=False, show_progress=False,
+                                                 _js='(x)=>{refresh_aspect_ratios_label(x);}')
+                    aspect_ratio_landscape.change(aspect_ratio_change, inputs=aspect_ratio_landscape,
+                                                  outputs=[aspect_ratio_square, aspect_ratio_portrait, aspect_ratio_landscape, aspect_ratios_selection_hidden],
+                                                  queue=False, show_progress=False,
                                                   _js='(x)=>{refresh_aspect_ratios_label(x);}')
-                    shared.gradio_root.load(lambda x: None, inputs=aspect_ratios_selection, queue=False, show_progress=False, _js='(x)=>{refresh_aspect_ratios_label(x);}')
+                    shared.gradio_root.load(lambda x: None, inputs=aspect_ratios_selection_hidden, queue=False, show_progress=False, _js='(x)=>{refresh_aspect_ratios_label(x);}')
+
+                    aspect_ratios_selection = aspect_ratios_selection_hidden
 
                 with gr.Accordion(label='Preset', open=False):
                     if not args_manager.args.disable_preset_selection:
@@ -648,12 +683,6 @@ with shared.gradio_root:
                 history_link = gr.HTML()
                 shared.gradio_root.load(update_history_link, outputs=history_link, queue=False, show_progress=False)
 
-            with gr.Tab(label='Styles'):
-                from modules import ui_prompt_styles as ui_styles
-                ui_styles_comp = ui_styles.UiPromptStyles('advanced', prompt, negative_prompt)
-                style_selections = ui_styles_comp.dropdown
-                csv_style = gr.State(None)
-
             with gr.Tab(label='Models'):
                 with gr.Group():
                     with gr.Row():
@@ -668,7 +697,8 @@ with shared.gradio_root:
                                                value=modules.config.default_refiner_switch,
                                                visible=modules.config.default_refiner_model_name != 'None')
 
-                    refiner_model.change(lambda x: gr.update(visible=x != 'None'),
+                    base_model.change(lambda x: modules.config.set_config_value('default_model', x), inputs=base_model, queue=False, show_progress=False)
+                    refiner_model.change(lambda x: (modules.config.set_config_value('default_refiner_model_name', x), gr.update(visible=x != 'None'))[1],
                                          inputs=refiner_model, outputs=refiner_switch, show_progress=False, queue=False)
 
                 with gr.Group():
@@ -681,13 +711,28 @@ with shared.gradio_root:
                             lora_model = gr.Dropdown(label=f'LoRA {i + 1}',
                                                      choices=['None'] + modules.config.lora_filenames, value=filename,
                                                      elem_classes='lora_model', scale=5)
-                            lora_weight = gr.Slider(label='Weight', minimum=modules.config.default_loras_min_weight,
+                    lora_weight = gr.Slider(label='Weight', minimum=modules.config.default_loras_min_weight,
                                                     maximum=modules.config.default_loras_max_weight, step=0.01, value=weight,
                                                     elem_classes='lora_weight', scale=5)
-                            lora_ctrls += [lora_enabled, lora_model, lora_weight]
+                    lora_ctrls += [lora_enabled, lora_model, lora_weight]
+
+                def update_loras(*vals):
+                    l = []
+                    for i in range(0, len(vals), 3):
+                        l.append([vals[i], vals[i + 1], vals[i + 2]])
+                    modules.config.set_config_value('default_loras', l)
+
+                for ctrl in lora_ctrls:
+                    ctrl.change(update_loras, inputs=lora_ctrls, queue=False, show_progress=False)
 
                 with gr.Row():
                     refresh_files = gr.Button(label='Refresh', value='\U0001f504 Refresh All Files', variant='secondary', elem_classes='refresh_button')
+
+            with gr.Tab(label='Styles'):
+                from modules import ui_prompt_styles as ui_styles
+                ui_styles_comp = ui_styles.UiPromptStyles('advanced', prompt, negative_prompt)
+                style_selections = ui_styles_comp.dropdown
+                csv_style = gr.State(None)
             with gr.Tab(label='Advanced'):
                 sharpness = gr.Slider(label='Image Sharpness', minimum=0.0, maximum=30.0, step=0.001,
                                       value=modules.config.default_sample_sharpness,


### PR DESCRIPTION
## Summary
- categorize aspect ratios by orientation
- remember selected model and LoRA configuration
- reorder advanced tabs so 'Models' is next to 'Settings'

## Testing
- `python -m py_compile webui.py modules/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1f2ed2a8832b90b9970a104dfb14