### PR TITLE
Handle invalid LoRA weight value

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -64,7 +64,13 @@ class AsyncTask:
         self.base_model_name = args.pop()
         self.refiner_model_name = args.pop()
         self.refiner_switch = args.pop()
-        self.loras = get_enabled_loras([(bool(args.pop()), str(args.pop()), float(args.pop())) for _ in
+        def _safe_float(v):
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return 0.0
+
+        self.loras = get_enabled_loras([(bool(args.pop()), str(args.pop()), _safe_float(args.pop())) for _ in
                                         range(default_max_lora_number)])
         self.input_image_checkbox = args.pop()
         self.current_tab = args.pop()


### PR DESCRIPTION
## Summary
- prevent crash when a LoRA weight value is not numeric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a22689bf4832b97cdc5d4338a118e