### PR TITLE
Fix controlnet type error

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -138,7 +138,7 @@ class AsyncTask:
             cn_stop = args.pop()
             cn_weight = args.pop()
             cn_type = args.pop()
-            if cn_img is not None:
+            if cn_img is not None and cn_type in self.cn_tasks:
                 self.cn_tasks[cn_type].append([cn_img, cn_stop, cn_weight])
 
         self.debugging_dino = args.pop()


### PR DESCRIPTION
## Summary
- guard against invalid controlnet types to avoid `KeyError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a27ae40d8832b9a30d68b79d44692