### PR TITLE
Fix argument misalignment

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -26,7 +26,11 @@ shared.prompt_styles = styles.StyleDatabase(["styles.csv", "styles_integrated.cs
 
 def get_task(*args):
     args = list(args)
-    args.pop(0)
+    # The previous pipeline step `prepare_seed` returns two values
+    # (`seed_actual` and `image_seed`) which are prepended to the
+    # user controls in the argument list.  Drop both of them so that
+    # `AsyncTask` receives the expected sequence of parameters only.
+    args = args[2:]
 
     return worker.AsyncTask(args=args)
 


### PR DESCRIPTION
## Summary
- correct argument stripping in `get_task` to drop both values from `prepare_seed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a291bbc14832bb7ad43ed88a1eec5