### PR TITLE
Fix style prompt merge crash

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -32,6 +32,13 @@ def get_task(*args):
     # `AsyncTask` receives the expected sequence of parameters only.
     args = args[2:]
 
+    # The first argument after the seeds is the current AsyncTask
+    # state.  It is not part of the parameters consumed by
+    # ``AsyncTask`` so remove it as well to keep the remaining values
+    # in the expected order.
+    if args:
+        args = args[1:]
+
     return worker.AsyncTask(args=args)
 
 def generate_clicked(task: worker.AsyncTask):


### PR DESCRIPTION
## Summary
- ignore `currentTask` parameter when building AsyncTask args so fields line up correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2fc06030832bacd19d2518ba31d5