### PR TITLE
Handle non-string style prompts

### DIFF
--- a/modules/prompt_style_system.py
+++ b/modules/prompt_style_system.py
@@ -12,7 +12,16 @@ class PromptStyle(typing.NamedTuple):
     path: str | None = None
 
 
-def merge_prompts(style_prompt: str, prompt: str) -> str:
+def merge_prompts(style_prompt: typing.Any, prompt: typing.Any) -> str:
+    """Merge *prompt* with *style_prompt* safely.
+
+    This helper now accepts any type for ``style_prompt`` and ``prompt`` and
+    gracefully ignores non-string values instead of raising an exception.
+    """
+
+    prompt = prompt if isinstance(prompt, str) else ""
+    style_prompt = style_prompt if isinstance(style_prompt, str) else ""
+
     if "{prompt}" in style_prompt:
         res = style_prompt.replace("{prompt}", prompt)
     else:

--- a/tests/test_prompt_style_system.py
+++ b/tests/test_prompt_style_system.py
@@ -1,0 +1,8 @@
+import unittest
+import modules.prompt_style_system as pss
+
+class TestPromptStyleSystem(unittest.TestCase):
+    def test_merge_prompts_ignores_non_string_inputs(self):
+        self.assertEqual(pss.merge_prompts(['a', 'b'], 'foo'), 'foo')
+        self.assertEqual(pss.merge_prompts('bar', ['foo']), 'bar')
+


### PR DESCRIPTION
## Summary
- sanitize arguments in `merge_prompts` to avoid crashes
- add regression test for merging non-string prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a33c07454832b8e4e8a916404609e