### PR TITLE
Add orientation labels and move Models tab

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -768,7 +768,8 @@ def add_ratio(x):
     a, b = x.replace('*', ' ').split(' ')[:2]
     a, b = int(a), int(b)
     g = math.gcd(a, b)
-    return f'{a}×{b} <span style="color: grey;"> \U00002223 {a // g}:{b // g}</span>'
+    orientation = 'Square' if a == b else ('Portrait' if a < b else 'Landscape')
+    return f'{a}×{b} <span style="color: grey;">{orientation} \U00002223 {a // g}:{b // g}</span>'
 
 
 default_aspect_ratio = add_ratio(default_aspect_ratio)

--- a/webui.py
+++ b/webui.py
@@ -648,12 +648,6 @@ with shared.gradio_root:
                 history_link = gr.HTML()
                 shared.gradio_root.load(update_history_link, outputs=history_link, queue=False, show_progress=False)
 
-            with gr.Tab(label='Styles'):
-                from modules import ui_prompt_styles as ui_styles
-                ui_styles_comp = ui_styles.UiPromptStyles('advanced', prompt, negative_prompt)
-                style_selections = ui_styles_comp.dropdown
-                csv_style = gr.State(None)
-
             with gr.Tab(label='Models'):
                 with gr.Group():
                     with gr.Row():
@@ -688,6 +682,12 @@ with shared.gradio_root:
 
                 with gr.Row():
                     refresh_files = gr.Button(label='Refresh', value='\U0001f504 Refresh All Files', variant='secondary', elem_classes='refresh_button')
+
+            with gr.Tab(label='Styles'):
+                from modules import ui_prompt_styles as ui_styles
+                ui_styles_comp = ui_styles.UiPromptStyles('advanced', prompt, negative_prompt)
+                style_selections = ui_styles_comp.dropdown
+                csv_style = gr.State(None)
             with gr.Tab(label='Advanced'):
                 sharpness = gr.Slider(label='Image Sharpness', minimum=0.0, maximum=30.0, step=0.001,
                                       value=modules.config.default_sample_sharpness,


### PR DESCRIPTION
## Summary
- reorder advanced tab to put Models next to Settings
- show orientation name beside width×height for aspect ratios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a686569b0832bae52ba8f99d01f02