### PR TITLE
UI fixes for history log and tooltip warnings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -402,7 +402,10 @@ div:has(> #positive_prompt) {
 }
 
 #history_button {
-  width: 100%;
-  font-size: 32px;
+  width: fit-content;
+  font-size: 20px;
   border-radius: 8px;
+  padding: 8px 16px;
+  background: #808080;
+  color: white;
 }

--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -462,6 +462,7 @@ if not hasattr(Block, 'original__init__'):
 
 def blk_ini(self, *args, **kwargs):
     all_components.append(self)
+    kwargs.pop('tooltip', None)
     return Block.original_init(self, *args, **kwargs)
 
 

--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -17,7 +17,12 @@ def get_current_html_path(output_format=None):
     output_format = output_format if output_format else modules.config.default_output_format
     date_string, local_temp_filename, only_name = generate_temp_filename(folder=modules.config.path_outputs,
                                                                          extension=output_format)
-    html_name = os.path.join(os.path.dirname(local_temp_filename), 'log.html')
+    output_dir = os.path.dirname(local_temp_filename)
+    html_name = os.path.join(output_dir, 'log.html')
+    os.makedirs(output_dir, exist_ok=True)
+    if not os.path.exists(html_name):
+        with open(html_name, 'w', encoding='utf-8') as f:
+            f.write("<!DOCTYPE html><html><body></body></html>")
     return html_name
 
 

--- a/webui.py
+++ b/webui.py
@@ -618,8 +618,10 @@ with shared.gradio_root:
                 def update_history_link():
                     if args_manager.args.disable_image_log:
                         return gr.update(value='')
-
-                    return gr.update(value=f'<button id="history_button" class="type_row" onclick="window.open(\'file={get_current_html_path(output_format)}\', \'_blank\')">\U0001F4DA History Log</button>')
+                    path = get_current_html_path(output_format)
+                    if os.path.exists(path):
+                        return gr.update(value=f'<button id="history_button" onclick="window.open(\'file={path}\', \'_blank\')">\U0001F4DA History Log</button>')
+                    return gr.update(value='')
 
                 def refresh_seed(seed_string):
                     try:


### PR DESCRIPTION
## Summary
- suppress unused tooltip warnings in Gradio
- ensure history log file exists when linking
- style history log button to be smaller and gray
- only show history log button when log exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aac033208832b90a4b355775c4664