### PR TITLE
UI tweaks for advanced panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -394,11 +394,17 @@ div:has(> #positive_prompt) {
 .seed_button {
   background: #eee !important;
   border: 1px solid #aaa !important;
-  width: 30px !important;
-  height: 30px !important;
+  width: 24px !important;
+  height: 24px !important;
   padding: 0 !important;
-  min-width: 30px !important;
+  min-width: 24px !important;
   border-radius: 4px;
+}
+
+.seed_row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 #history_button {


### PR DESCRIPTION
## Summary
- store aspect ratio in raw form
- shrink seed button styling and align row
- tweak advanced settings layout with sampler/scheduler row and add step and clip skip sliders
- sync user sliders with debug controls

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aade03fec832b9f309210b03740c2