### PR TITLE
Fix invalid MetadataScheme handling

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -116,8 +116,14 @@ class AsyncTask:
         self.inpaint_erode_or_dilate = args.pop()
         self.save_final_enhanced_image_only = args.pop() if not args_manager.args.disable_image_log else False
         self.save_metadata_to_images = args.pop() if not args_manager.args.disable_metadata else False
-        self.metadata_scheme = MetadataScheme(
-            args.pop()) if not args_manager.args.disable_metadata else MetadataScheme.FOOOCUS
+        if not args_manager.args.disable_metadata:
+            metadata_value = args.pop()
+            try:
+                self.metadata_scheme = MetadataScheme(metadata_value)
+            except ValueError:
+                self.metadata_scheme = MetadataScheme.FOOOCUS
+        else:
+            self.metadata_scheme = MetadataScheme.FOOOCUS
 
         self.cn_tasks = {x: [] for x in ip_list}
         for _ in range(modules.config.default_controlnet_image_count):


### PR DESCRIPTION
## Summary
- handle unexpected metadata scheme values by defaulting to `fooocus`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab5ca7fac832b8ae892f3d2b1b25b