### PR TITLE
Fix aspect ratio persistence and layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -119,9 +119,37 @@ div:has(> #positive_prompt) {
     flex: calc(50% - 5px) !important;
 }
 
-.aspect_ratios label span {
-    white-space: nowrap !important;
+.aspect_ratios label:nth-child(n+3):nth-child(-n+6) {
+    flex: calc(25% - 5px) !important;
 }
+
+/* shape for ratio buttons */
+.aspect_ratios label span {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap !important;
+    border: 1px solid var(--border-color-primary);
+    border-radius: 4px;
+    padding: 4px 2px;
+}
+
+.aspect_ratios label:nth-child(1) span,
+.aspect_ratios label:nth-child(2) span {
+    aspect-ratio: 1 / 1;
+    width: 60px;
+}
+
+.aspect_ratios label:nth-child(n+3):nth-child(-n+6) span {
+    aspect-ratio: 2 / 3;
+    width: 40px;
+}
+
+.aspect_ratios label:nth-child(n+7) span {
+    aspect-ratio: 3 / 2;
+    width: 60px;
+}
+
 
 .aspect_ratios label input {
     margin-left: 0 !important;

--- a/modules/config.py
+++ b/modules/config.py
@@ -768,8 +768,7 @@ def add_ratio(x):
     a, b = x.replace('*', ' ').split(' ')[:2]
     a, b = int(a), int(b)
     g = math.gcd(a, b)
-    orientation = 'Square' if a == b else ('Portrait' if a < b else 'Landscape')
-    return f'{a}×{b} <span style="color: grey;">{orientation} \U00002223 {a // g}:{b // g}</span>'
+    return f'{a}×{b} <span style="color: grey;">\u2223 {a // g}:{b // g}</span>'
 
 
 default_aspect_ratio = add_ratio(default_aspect_ratio)


### PR DESCRIPTION
## Summary
- simplify aspect ratio labels to remove orientation text
- style aspect ratio radio buttons with shapes
- layout portrait ratios in a single row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abefe1674832ba2272a99f3adf907