### PR TITLE
Fix duplication of aspect ratio icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -133,7 +133,7 @@ div:has(> #positive_prompt) {
     padding: 4px 2px;
 }
 
-.aspect_ratios label span::after {
+.aspect_ratios label > span::after {
     content: '';
     display: inline-block;
     margin-left: 4px;
@@ -142,16 +142,16 @@ div:has(> #positive_prompt) {
     border-radius: 2px;
 }
 
-.aspect_ratios label:nth-child(1) span::after,
-.aspect_ratios label:nth-child(2) span::after {
+.aspect_ratios label:nth-child(1) > span::after,
+.aspect_ratios label:nth-child(2) > span::after {
     aspect-ratio: 1 / 1;
 }
 
-.aspect_ratios label:nth-child(n+3):nth-child(-n+6) span::after {
+.aspect_ratios label:nth-child(n+3):nth-child(-n+6) > span::after {
     aspect-ratio: 2 / 3;
 }
 
-.aspect_ratios label:nth-child(n+7) span::after {
+.aspect_ratios label:nth-child(n+7) > span::after {
     aspect-ratio: 3 / 2;
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate squares in aspect ratio labels by targeting only direct span

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac4a1e210832b997d714e8350d663