### PR TITLE
Update aspect ratio buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -135,33 +135,34 @@ div:has(> #positive_prompt) {
 }
 
 /* ratio text with small icon */
-.aspect_ratios label span {
-    display: inline-flex !important;
+
+/* visual icon container */
+.aspect_ratios_group label span {
+    border-radius: 6px;
+    border: 1px solid #444;
+    background-color: #222;
+    margin-left: auto;
+    display: inline-flex;
+    justify-content: center;
     align-items: center;
-    white-space: nowrap !important;
-    padding: 4px 2px;
+    min-width: 36px;
+    min-height: 36px;
 }
 
-.aspect_ratios label > span::after {
-    content: '';
-    display: inline-block;
-    margin-left: 4px;
-    width: 12px;
-    border: 1px solid var(--border-color-primary);
-    border-radius: 2px;
+/* shape variations */
+.square-ratio {
+  width: 48px;
+  aspect-ratio: 1 / 1;
 }
 
-.aspect_ratios label:nth-child(1) > span::after,
-.aspect_ratios label:nth-child(2) > span::after {
-    aspect-ratio: 1 / 1;
+.portrait-ratio {
+  width: 36px;
+  aspect-ratio: 5 / 12;
 }
 
-.aspect_ratios label:nth-child(n+3):nth-child(-n+6) > span::after {
-    aspect-ratio: 2 / 3;
-}
-
-.aspect_ratios label:nth-child(n+7) > span::after {
-    aspect-ratio: 3 / 2;
+.landscape-ratio {
+  width: 64px;
+  aspect-ratio: 12 / 5;
 }
 
 

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -77,9 +77,9 @@ onUiLoaded(async () => {
         let labels = Array.from(aspectContainer.querySelectorAll('label'));
         aspectContainer.innerHTML = '';
         const groups = [
-            {title: 'Square', count: 2},
-            {title: 'Portrait', count: 4},
-            {title: 'Landscape', count: labels.length - 6}
+            {title: 'Square', count: 2, cls: 'square-ratio'},
+            {title: 'Portrait', count: 4, cls: 'portrait-ratio'},
+            {title: 'Landscape', count: labels.length - 6, cls: 'landscape-ratio'}
         ];
         let idx = 0;
         groups.forEach(g => {
@@ -92,7 +92,15 @@ onUiLoaded(async () => {
             grp.appendChild(title);
             for (let i = 0; i < g.count; i++) {
                 if (labels[idx]) {
-                    grp.appendChild(labels[idx]);
+                    let label = labels[idx];
+                    let span = label.querySelector('span');
+                    if (span) {
+                        let text = span.textContent;
+                        span.textContent = '';
+                        span.classList.add(g.cls);
+                        label.appendChild(document.createTextNode(text));
+                    }
+                    grp.appendChild(label);
                 } else {
                     let blank = document.createElement('div');
                     blank.style.flex = '0 0 calc(50% - 5px)';


### PR DESCRIPTION
## Summary
- tweak UI for aspect ratio buttons with visually representative icons
- regroup options and apply aspect ratio classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684accd99904832ba34a2266fd281134