### PR TITLE
Shrink & reposition aspect ratio icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,6 +126,8 @@ div:has(> #positive_prompt) {
 .aspect_ratios_group label {
     flex: 0 0 calc(50% - 5px);
     box-sizing: border-box;
+    display: flex;
+    align-items: center;
 }
 
 .aspect_ratios_group > div:first-child {
@@ -138,30 +140,33 @@ div:has(> #positive_prompt) {
 
 /* visual icon container */
 .aspect_ratios_group label span {
-    border-radius: 6px;
+    border-radius: 4px;
     border: 1px solid #444;
-    background-color: #222;
-    margin-left: auto;
+    background-color: #3b82f6;
+    margin-left: 8px;
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    min-width: 36px;
-    min-height: 36px;
+    min-width: 20px;
+    min-height: 20px;
 }
 
 /* shape variations */
+
 .square-ratio {
-  width: 48px;
+  width: 32px;
   aspect-ratio: 1 / 1;
 }
 
+
 .portrait-ratio {
-  width: 36px;
+  width: 20px;
   aspect-ratio: 5 / 12;
 }
 
+
 .landscape-ratio {
-  width: 64px;
+  width: 52px;
   aspect-ratio: 12 / 5;
 }
 

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -98,7 +98,7 @@ onUiLoaded(async () => {
                         let text = span.textContent;
                         span.textContent = '';
                         span.classList.add(g.cls);
-                        label.appendChild(document.createTextNode(text));
+                        label.insertBefore(document.createTextNode(text), span);
                     }
                     grp.appendChild(label);
                 } else {


### PR DESCRIPTION
## Summary
- make aspect ratio labels flex containers
- shrink visual icons, color them blue, and adjust their positions
- show ratio text before icon

## Testing
- `pytest tests/test_extra_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684acf0c1d30832bbb0f99fdd51b763a