### PR TITLE
Update seed controls layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -436,14 +436,14 @@ div:has(> #positive_prompt) {
 #seed-container {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   width: 100%;
-  padding: 10px 14px;
+  padding: 8px 12px;
   box-sizing: border-box;
 }
 
 #seed-input {
-  flex: 1;
+  flex: 7;
   height: 36px;
   padding: 6px 10px;
   font-size: 14px;
@@ -451,11 +451,10 @@ div:has(> #positive_prompt) {
 }
 
 #dice-btn, #back-btn {
-  width: 36px;
+  flex: 1.5;
   height: 36px;
-  aspect-ratio: 1 / 1;
+  font-size: 14px;
   padding: 0;
-  font-size: 16px;
   border-radius: 6px;
   box-sizing: border-box;
 }

--- a/webui.py
+++ b/webui.py
@@ -583,7 +583,7 @@ with shared.gradio_root:
                     with gr.Row(elem_id="seed-container"):
                         seed_input = gr.Number(label="Seed", value=-1, elem_id="seed-input")
                         dice_btn = gr.Button("\U0001f3b2", elem_id="dice-btn")
-                        back_btn = gr.Button("\u2190 BACK", elem_id="back-btn")
+                        back_btn = gr.Button("\u267b\ufe0f", elem_id="back-btn")
                         dice_btn.click(lambda: -1, outputs=seed_input, queue=False, show_progress=False)
                         back_btn.click(lambda x: x, inputs=seed_actual, outputs=seed_input, queue=False, show_progress=False)
 


### PR DESCRIPTION
## Summary
- tweak seed control layout style for 70/30 split
- switch back button to use ♻️ icon

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad90c14ac832bbda5e54a2c4d8b72