### PR TITLE
Align seed input layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -447,14 +447,20 @@ div:has(> #positive_prompt) {
   height: 36px;
   padding: 6px 10px;
   font-size: 14px;
+  border-radius: 6px;
   box-sizing: border-box;
 }
 
-#dice-btn, #back-btn {
+#dice-btn, #recycle-btn {
   flex: 1.5;
   height: 36px;
-  font-size: 14px;
-  padding: 0;
+  aspect-ratio: 1;
+  font-size: 16px;
   border-radius: 6px;
+  padding: 0;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  cursor: pointer;
   box-sizing: border-box;
 }

--- a/webui.py
+++ b/webui.py
@@ -580,12 +580,12 @@ with shared.gradio_root:
 
                 with gr.Accordion(label='Advanced', open=False):
 
-                    with gr.Row(elem_id="seed-container"):
+                    with gr.Box(elem_id="seed-container"):
                         seed_input = gr.Number(label="Seed", value=-1, elem_id="seed-input")
                         dice_btn = gr.Button("\U0001f3b2", elem_id="dice-btn")
-                        back_btn = gr.Button("\u267b\ufe0f", elem_id="back-btn")
+                        recycle_btn = gr.Button("\u267b\ufe0f", elem_id="recycle-btn")
                         dice_btn.click(lambda: -1, outputs=seed_input, queue=False, show_progress=False)
-                        back_btn.click(lambda x: x, inputs=seed_actual, outputs=seed_input, queue=False, show_progress=False)
+                        recycle_btn.click(lambda x: x, inputs=seed_actual, outputs=seed_input, queue=False, show_progress=False)
 
                     sampler_name = gr.Dropdown(label='Sampler', choices=flags.sampler_list,
                                                value=modules.config.default_sampler)


### PR DESCRIPTION
## Summary
- use `gr.Box` for seed entry
- rename `back-btn` to `recycle-btn`
- update CSS to style new layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adbcf1904832b847c20d17dfd0ec6