### PR TITLE
Set 832×1216 as default aspect ratio

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -483,7 +483,7 @@ available_aspect_ratios = get_config_item_or_set_default(
 )
 default_aspect_ratio = get_config_item_or_set_default(
     key='default_aspect_ratio',
-    default_value='1152*896' if '1152*896' in available_aspect_ratios else available_aspect_ratios[0],
+    default_value='832*1216' if '832*1216' in available_aspect_ratios else available_aspect_ratios[0],
     validator=lambda x: x in available_aspect_ratios,
     expected_type=str
 )

--- a/presets/default.json
+++ b/presets/default.json
@@ -41,7 +41,7 @@
         "Fooocus Enhance",
         "Fooocus Sharp"
     ],
-    "default_aspect_ratio": "1152*896",
+    "default_aspect_ratio": "832*1216",
     "default_overwrite_step": -1,
     "checkpoint_downloads": {
         "juggernautXL_v8Rundiffusion.safetensors": "https://huggingface.co/lllyasviel/fav_models/resolve/main/fav/juggernautXL_v8Rundiffusion.safetensors"


### PR DESCRIPTION
## Summary
- set default aspect ratio to `832*1216` in config
- update default preset to match

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeadc8750832ba94192695445cda5