### PR TITLE
Persist last aspect ratio

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -483,7 +483,7 @@ available_aspect_ratios = get_config_item_or_set_default(
 )
 default_aspect_ratio = get_config_item_or_set_default(
     key='default_aspect_ratio',
-    default_value='832*1216' if '832*1216' in available_aspect_ratios else available_aspect_ratios[0],
+    default_value=available_aspect_ratios[0],
     validator=lambda x: x in available_aspect_ratios,
     expected_type=str
 )


### PR DESCRIPTION
## Summary
- default to the first available ratio and rely on saved value for persistence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aed8df308832b85b9397b61492138