### PR TITLE
Fix private logger file initialization

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -13,9 +13,10 @@ from modules.util import generate_temp_filename
 log_cache = {}
 
 
-def get_current_html_path(output_format=None):
+def get_current_html_path(output_format=None, folder=None):
     output_format = output_format if output_format else modules.config.default_output_format
-    date_string, local_temp_filename, only_name = generate_temp_filename(folder=modules.config.path_outputs,
+    folder = folder if folder else modules.config.path_outputs
+    date_string, local_temp_filename, only_name = generate_temp_filename(folder=folder,
                                                                          extension=output_format)
     output_dir = os.path.dirname(local_temp_filename)
     html_name = os.path.join(output_dir, 'log.html')
@@ -53,7 +54,7 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
     if args_manager.args.disable_image_log:
         return local_temp_filename
 
-    html_name = os.path.join(os.path.dirname(local_temp_filename), 'log.html')
+    html_name = get_current_html_path(output_format=output_format, folder=path_outputs)
 
     css_styles = (
         "<style>"

--- a/webui.py
+++ b/webui.py
@@ -18,7 +18,7 @@ import copy
 import launch
 from extras.inpaint_mask import SAMOptions
 from modules.private_logger import get_current_html_path
-from modules.ui_gradio_extensions import reload_javascript
+from modules.ui_gradio_extensions import reload_javascript, webpath
 from modules.auth import auth_enabled, check_auth
 from modules.util import is_json
 
@@ -620,7 +620,7 @@ with shared.gradio_root:
                         return gr.update(value='')
                     path = get_current_html_path(output_format)
                     if os.path.exists(path):
-                        return gr.update(value=f'<button id="history_button" onclick="window.open(\'file={path}\', \'_blank\')">\U0001F4DA History Log</button>')
+                        return gr.update(value=f'<button id="history_button" onclick="window.open(\'{webpath(path)}\', \"_blank\")">\U0001F4DA History Log</button>')
                     return gr.update(value='')
 
                 def refresh_seed(seed_string):


### PR DESCRIPTION
## Summary
- create log.html if missing via `get_current_html_path`
- reuse new helper inside `log()`
- sanitize History Log link path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b04295fec832bb3fe301f0e4e22a7