### PR TITLE
Add improved tag autocomplete UI

### DIFF
--- a/javascript/tag_autocomplete.js
+++ b/javascript/tag_autocomplete.js
@@ -2,6 +2,48 @@
 // Loads tags from danbooru.csv and shows suggestions while typing
 
 (function(){
+    // caret position helper from textarea-caret-position
+    function getCaretCoordinates(element, position){
+        const properties=["direction","boxSizing","width","height","overflowX","overflowY","borderTopWidth","borderRightWidth","borderBottomWidth","borderLeftWidth","borderStyle","paddingTop","paddingRight","paddingBottom","paddingLeft","fontStyle","fontVariant","fontWeight","fontStretch","fontSize","fontSizeAdjust","lineHeight","fontFamily","textAlign","textTransform","textIndent","textDecoration","letterSpacing","wordSpacing","tabSize","MozTabSize"];
+        const div=document.createElement('div');
+        document.body.appendChild(div);
+        const style=div.style;
+        const computed=window.getComputedStyle?window.getComputedStyle(element):element.currentStyle;
+        const isInput=element.nodeName==='INPUT';
+        style.whiteSpace='pre-wrap';
+        if(!isInput) style.wordWrap='break-word';
+        style.position='absolute';
+        style.visibility='hidden';
+        properties.forEach(prop=>{
+            if(isInput && prop==='lineHeight'){
+                if(computed.boxSizing==='border-box'){
+                    const height=parseInt(computed.height);
+                    const outerHeight=parseInt(computed.paddingTop)+parseInt(computed.paddingBottom)+parseInt(computed.borderTopWidth)+parseInt(computed.borderBottomWidth);
+                    const targetHeight=outerHeight+parseInt(computed.lineHeight);
+                    if(height>targetHeight) style.lineHeight=height-outerHeight+'px';
+                    else if(height===targetHeight) style.lineHeight=computed.lineHeight;
+                    else style.lineHeight=0;
+                } else {
+                    style.lineHeight=computed.height;
+                }
+            } else {
+                style[prop]=computed[prop];
+            }
+        });
+        style.overflow='hidden';
+        div.textContent=element.value.substring(0,position);
+        if(isInput) div.textContent=div.textContent.replace(/\s/g,'\u00a0');
+        const span=document.createElement('span');
+        span.textContent=element.value.substring(position)||'.';
+        div.appendChild(span);
+        const coordinates={
+            top:span.offsetTop+parseInt(computed.borderTopWidth),
+            left:span.offsetLeft+parseInt(computed.borderLeftWidth),
+            height:parseInt(computed.lineHeight)
+        };
+        document.body.removeChild(div);
+        return coordinates;
+    }
     const TAG_PATH = 'file=a1111-sd-webui-tagcomplete/tags/danbooru.csv';
     let tags = [];
     let container; // suggestion container
@@ -27,6 +69,9 @@
         container.style.display = 'none';
         container.style.maxHeight = '200px';
         container.style.overflowY = 'auto';
+        container.style.borderRadius = '8px';
+        container.style.boxShadow = '0 2px 5px rgba(0,0,0,0.2)';
+        container.style.minWidth = '150px';
         area.parentElement.style.position = 'relative';
         area.parentElement.appendChild(container);
     }
@@ -46,11 +91,16 @@
             return;
         }
         container.innerHTML = '';
+        const colors = ['#ffa500','#f48fb1','#f06292','#ec407a','#e91e63'];
         results.forEach((t,i)=>{
             const div = document.createElement('div');
-            div.textContent = t;
+            const pre = t.substring(0, fragment.length);
+            const post = t.substring(fragment.length);
+            const color = colors[(i+1)%colors.length];
+            div.innerHTML = `<span style="color:${colors[0]}">${pre}</span><span style="color:${color}">${post}</span>`;
             div.style.padding = '2px 4px';
             div.style.cursor = 'pointer';
+            div.dataset.tag = t;
             if(i===selected){
                 div.style.background = '#ddd';
             }
@@ -60,10 +110,10 @@
             });
             container.appendChild(div);
         });
-        const rect = area.getBoundingClientRect();
-        container.style.left = '0px';
-        container.style.top = (area.offsetTop + area.offsetHeight) + 'px';
-        container.style.width = rect.width + 'px';
+        const caret = getCaretCoordinates(area, area.selectionStart);
+        container.style.left = (caret.left - area.scrollLeft) + 'px';
+        container.style.top = (caret.top - area.scrollTop + caret.height) + 'px';
+        container.style.width = 'auto';
         container.style.display = 'block';
         selected = -1;
     }
@@ -97,7 +147,7 @@
                 if(selected>=0){
                     e.preventDefault();
                     const fragment = area.value.substring(0, area.selectionStart).split(/[,\n]/).pop().trim();
-                    insert(area, fragment, items[selected].textContent);
+                    insert(area, fragment, items[selected].dataset.tag);
                 }
             } else if(e.key==='Escape'){
                 container.style.display='none';


### PR DESCRIPTION
## Summary
- enhance the javascript tag autocomplete
  - add caret position helper
  - add rounded suggestion box with shadow
  - colorize suggestions and position under cursor
  - ensure dataset attribute used for insertion
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcc35f368832ba3f952f5ebd96869