### PR TITLE
Improve tag autocomplete

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -1,6 +1,7 @@
 # based on https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/v1.6.0/modules/ui_gradio_extensions.py
 
 import os
+import json
 import gradio as gr
 import args_manager
 
@@ -31,6 +32,9 @@ def javascript_html():
     viewer_js_path = webpath('javascript/viewer.js')
     image_viewer_js_path = webpath('javascript/imageviewer.js')
     tag_autocomplete_js_path = webpath('javascript/tag_autocomplete.js')
+    tag_dir = os.path.join(script_path, 'a1111-sd-webui-tagcomplete', 'tags')
+    tag_files = [os.path.join('a1111-sd-webui-tagcomplete', 'tags', f) for f in os.listdir(tag_dir) if f.endswith('.csv')]
+    tag_files_json = json.dumps(tag_files)
     samples_path = webpath(os.path.abspath('./sdxl_styles/samples/fooocus_v2.jpg'))
     head = f'<script type="text/javascript">{localization_js(args_manager.args.language)}</script>\n'
     head += f'<script type="text/javascript" src="{script_js_path}"></script>\n'
@@ -41,6 +45,7 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{image_viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{tag_autocomplete_js_path}"></script>\n'
+    head += f'<script type="text/javascript">window.tag_csv_files = {tag_files_json};</script>\n'
     head += f'<meta name="samples-path" content="{samples_path}">\n'
 
     if args_manager.args.theme:


### PR DESCRIPTION
## Summary
- list all tag csv files via ui script helper
- load all tag csv files in `tag_autocomplete.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684dd5f5247c832b97f9bfa917c75fbb