### PR TITLE
Improve autocomplete insertion

### DIFF
--- a/javascript/tag_autocomplete.js
+++ b/javascript/tag_autocomplete.js
@@ -182,11 +182,12 @@
         const before = area.value.substring(0, cursorPos);
         const after = area.value.substring(cursorPos);
         const start = before.lastIndexOf(fragment);
-        area.value = before.substring(0,start) + tag + after;
-        area.selectionStart = area.selectionEnd = start + tag.length;
-        container.style.display='none';
+        const insertion = tag + ', ';
+        area.value = before.substring(0, start) + insertion + after;
+        area.selectionStart = area.selectionEnd = start + insertion.length;
+        container.style.display = 'none';
         skipInput = true;
-        area.dispatchEvent(new Event('input',{bubbles:true}));
+        area.dispatchEvent(new Event('input', { bubbles: true }));
     }
 
     function attach(area){


### PR DESCRIPTION
## Summary
- append a comma and space after inserting autocomplete tags

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684ddf56c290832bb6ef4d8f2761e6ed