### PR TITLE
Add Tag Autocomplete wildcard folder

### DIFF
--- a/a1111-sd-webui-tagcomplete/wildcards/README.md
+++ b/a1111-sd-webui-tagcomplete/wildcards/README.md
@@ -1,0 +1,3 @@
+# Tag Autocomplete Wildcards
+
+Place custom wildcard files here to use them with the Tag Autocomplete extension.

--- a/a1111-sd-webui-tagcomplete/wildcards/sample.txt
+++ b/a1111-sd-webui-tagcomplete/wildcards/sample.txt
@@ -1,0 +1,3 @@
+sample_option_1
+sample_option_2
+sample_option_3

--- a/readme.md
+++ b/readme.md
@@ -408,6 +408,8 @@ You can also disable randomness and process a wildcard file from top to bottom b
 
 Wildcards can be nested and combined, and multiple wildcards can be used in the same prompt (example see `wildcards/color_flower.txt`).
 
+Tag Autocomplete integrates with these wildcard files. Typing `__` (double underscore) shows all available wildcard files, and choosing one lists the replacement options inside. Wildcards placed in any extension's `wildcards` folder are detected automatically. This repository provides `a1111-sd-webui-tagcomplete/wildcards` as a dedicated location for custom wildcard files.
+
 ### Array Processing
 
 Example prompt: `[[red, green, blue]] flower`


### PR DESCRIPTION
## Summary
- document how Tag Autocomplete supports wildcards
- add a dedicated wildcard folder inside the tagcomplete extension
- provide sample wildcard file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de5365c6c832b9ec5b498c91c0e1f