### PR TITLE
Add SD Upscale checkbox

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -70,6 +70,10 @@ class AsyncTask:
         self.current_tab = args.pop()
         self.uov_method = args.pop()
         self.uov_input_image = args.pop()
+        self.sd_upscale_checkbox = args.pop()
+        self.sd_upscale_tile_overlap = args.pop()
+        self.sd_upscale_scale_factor = args.pop()
+        self.sd_upscale_upscaler = args.pop()
         self.outpaint_selections = args.pop()
         self.inpaint_input_image = args.pop()
         self.inpaint_additional_prompt = args.pop()
@@ -201,6 +205,8 @@ def worker():
     import modules.core as core
     import modules.flags as flags
     import modules.patch
+    from PIL import Image
+    import modules.sd_upscale
     import ldm_patched.modules.model_management
     import extras.preprocessors as preprocessors
     import modules.inpaint_worker as inpaint_worker
@@ -596,6 +602,14 @@ def worker():
         progressbar(async_task, current_progress, f'Upscaling image from {str((W, H))} ...')
         uov_input_image = perform_upscale(uov_input_image)
         print(f'Image upscaled.')
+        if async_task.sd_upscale_checkbox:
+            pil_img = Image.fromarray(uov_input_image)
+            pil_img = modules.sd_upscale.upscale_image(
+                pil_img,
+                overlap=int(async_task.sd_upscale_tile_overlap),
+                scale_factor=float(async_task.sd_upscale_scale_factor)
+            )
+            uov_input_image = np.array(pil_img)
         if '1.5x' in uov_method:
             f = 1.5
         elif '2x' in uov_method:

--- a/modules/config.py
+++ b/modules/config.py
@@ -586,6 +586,30 @@ default_overwrite_upscale = get_config_item_or_set_default(
     default_value=-1,
     validator=lambda x: isinstance(x, numbers.Number)
 )
+default_sd_upscale_checkbox = get_config_item_or_set_default(
+    key='default_sd_upscale_checkbox',
+    default_value=False,
+    validator=lambda x: isinstance(x, bool),
+    expected_type=bool
+)
+default_sd_upscale_tile_overlap = get_config_item_or_set_default(
+    key='default_sd_upscale_tile_overlap',
+    default_value=64,
+    validator=lambda x: isinstance(x, int) and 0 <= x <= 256,
+    expected_type=int
+)
+default_sd_upscale_scale_factor = get_config_item_or_set_default(
+    key='default_sd_upscale_scale_factor',
+    default_value=2.0,
+    validator=lambda x: isinstance(x, numbers.Number),
+    expected_type=numbers.Number
+)
+default_sd_upscale_upscaler = get_config_item_or_set_default(
+    key='default_sd_upscale_upscaler',
+    default_value='None',
+    validator=lambda x: isinstance(x, str),
+    expected_type=str
+)
 example_inpaint_prompts = get_config_item_or_set_default(
     key='example_inpaint_prompts',
     default_value=[

--- a/modules/sd_upscale.py
+++ b/modules/sd_upscale.py
@@ -1,0 +1,54 @@
+import math
+from dataclasses import dataclass
+from typing import List
+
+from PIL import Image
+
+DEFAULT_UPSCALERS = ['None']
+
+
+@dataclass
+class Grid:
+    image_w: int
+    image_h: int
+    tile_w: int
+    tile_h: int
+    overlap: int
+    tiles: List
+
+
+def split_grid(image: Image.Image, tile_w: int = 512, tile_h: int = 512, overlap: int = 64) -> Grid:
+    w, h = image.size
+    grid = Grid(image_w=w, image_h=h, tile_w=tile_w, tile_h=tile_h, overlap=overlap, tiles=[])
+    cols = max(math.ceil((w - overlap) / float(tile_w - overlap)), 1)
+    rows = max(math.ceil((h - overlap) / float(tile_h - overlap)), 1)
+    dx = (w - tile_w) / max(cols - 1, 1)
+    dy = (h - tile_h) / max(rows - 1, 1)
+    for row in range(rows):
+        y = int(row * dy)
+        row_images = []
+        for col in range(cols):
+            x = int(col * dx)
+            tile = image.crop((x, y, x + tile_w, y + tile_h))
+            row_images.append([x, tile_w, tile])
+        grid.tiles.append([y, tile_h, row_images])
+    return grid
+
+
+def combine_grid(grid: Grid) -> Image.Image:
+    combined_image = Image.new('RGB', (grid.image_w, grid.image_h))
+    for y, h, row in grid.tiles:
+        for x, w, tile in row:
+            combined_image.paste(tile.crop((0, 0, w, h)), (x, y))
+    return combined_image
+
+
+def upscale_image(image: Image.Image, overlap: int, scale_factor: float, tile_size: int = 512) -> Image.Image:
+    if scale_factor != 1.0:
+        w = int(image.width * scale_factor)
+        h = int(image.height * scale_factor)
+        image = image.resize((w, h), resample=Image.LANCZOS)
+    grid = split_grid(image, tile_w=tile_size, tile_h=tile_size, overlap=overlap)
+    # Placeholder processing: normally each tile would be sent through diffusion
+    combined = combine_grid(grid)
+    return combined

--- a/webui.py
+++ b/webui.py
@@ -15,6 +15,7 @@ from modules import styles
 import modules.meta_parser
 import args_manager
 import copy
+import modules.sd_upscale
 import launch
 from extras.inpaint_mask import SAMOptions
 from modules.private_logger import get_current_html_path
@@ -212,6 +213,21 @@ with shared.gradio_root:
                                 uov_input_image = grh.Image(label='Image', source='upload', type='numpy', show_label=False)
                             with gr.Column():
                                 uov_method = gr.Radio(label='Upscale or Variation:', choices=flags.uov_list, value=modules.config.default_uov_method)
+                                sd_upscale_checkbox = gr.Checkbox(label='SD Upscale', value=modules.config.default_sd_upscale_checkbox)
+                                with gr.Column(visible=modules.config.default_sd_upscale_checkbox) as sd_upscale_panel:
+                                    sd_tile_overlap = gr.Slider(minimum=0, maximum=256, step=16,
+                                                               label='Tile overlap',
+                                                               value=modules.config.default_sd_upscale_tile_overlap)
+                                    sd_scale_factor = gr.Slider(minimum=1.0, maximum=4.0, step=0.05,
+                                                                label='Scale Factor',
+                                                                value=modules.config.default_sd_upscale_scale_factor)
+                                    sd_upscaler = gr.Dropdown(label='Upscaler',
+                                                             choices=modules.sd_upscale.DEFAULT_UPSCALERS,
+                                                             value=modules.config.default_sd_upscale_upscaler)
+                                sd_upscale_checkbox.change(lambda x: gr.update(visible=x),
+                                                           inputs=sd_upscale_checkbox,
+                                                           outputs=sd_upscale_panel,
+                                                           queue=False, show_progress=False)
                                 gr.HTML('<a href="https://github.com/lllyasviel/Fooocus/discussions/390" target="_blank">\U0001F4D4 Documentation</a>')
                     with gr.Tab(label='Image Prompt', id='ip_tab') as ip_tab:
                         with gr.Row():
@@ -1008,7 +1024,7 @@ with shared.gradio_root:
 
         ctrls += [base_model, refiner_model, refiner_switch] + lora_ctrls
         ctrls += [input_image_checkbox, current_tab]
-        ctrls += [uov_method, uov_input_image]
+        ctrls += [uov_method, uov_input_image, sd_upscale_checkbox, sd_tile_overlap, sd_scale_factor, sd_upscaler]
         ctrls += [outpaint_selections, inpaint_input_image, inpaint_additional_prompt, inpaint_mask_image]
         ctrls += [disable_preview, disable_intermediate_results, disable_seed_increment, black_out_nsfw]
         ctrls += [adm_scaler_positive, adm_scaler_negative, adm_scaler_end, adaptive_cfg, clip_skip]


### PR DESCRIPTION
## Summary
- add placeholder sd_upscale module with tiling utilities
- expose sd upscale settings in configuration
- show SD Upscale UI controls and pass through task pipeline
- handle SD Upscale in async_worker apply_upscale

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df387e1f4832b8a946d50c4b9efca