### PR TITLE
Add SD upscale denoising control

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -73,6 +73,7 @@ class AsyncTask:
         self.sd_upscale_checkbox = args.pop()
         self.sd_upscale_tile_overlap = args.pop()
         self.sd_upscale_scale_factor = args.pop()
+        self.sd_upscale_denoising_strength = args.pop()
         self.sd_upscale_upscaler = args.pop()
         self.outpaint_selections = args.pop()
         self.inpaint_input_image = args.pop()
@@ -637,7 +638,7 @@ def worker():
             return direct_return, uov_input_image, None, None, None, None, None, current_progress
 
         tiled = True
-        denoising_strength = 0.382
+        denoising_strength = float(async_task.sd_upscale_denoising_strength)
         if async_task.overwrite_upscale_strength > 0:
             denoising_strength = async_task.overwrite_upscale_strength
         initial_pixels = core.numpy_to_pytorch(uov_input_image)

--- a/modules/config.py
+++ b/modules/config.py
@@ -604,6 +604,12 @@ default_sd_upscale_scale_factor = get_config_item_or_set_default(
     validator=lambda x: isinstance(x, numbers.Number),
     expected_type=numbers.Number
 )
+default_sd_upscale_denoising_strength = get_config_item_or_set_default(
+    key='default_sd_upscale_denoising_strength',
+    default_value=0.25,
+    validator=lambda x: isinstance(x, numbers.Number) and 0.0 <= x <= 1.0,
+    expected_type=numbers.Number
+)
 default_sd_upscale_upscaler = get_config_item_or_set_default(
     key='default_sd_upscale_upscaler',
     default_value='None',

--- a/modules/sd_upscale.py
+++ b/modules/sd_upscale.py
@@ -3,8 +3,19 @@ from dataclasses import dataclass
 from typing import List
 
 from PIL import Image
+from ldm_patched.utils import path_utils
 
-DEFAULT_UPSCALERS = ['None']
+
+def _find_upscalers():
+    try:
+        models = path_utils.get_filename_list("upscale_models")
+    except Exception as e:
+        print(f"Failed to load upscale models: {e}")
+        models = []
+    return ['None'] + models
+
+
+DEFAULT_UPSCALERS = _find_upscalers()
 
 
 @dataclass

--- a/webui.py
+++ b/webui.py
@@ -221,6 +221,9 @@ with shared.gradio_root:
                                     sd_scale_factor = gr.Slider(minimum=1.0, maximum=4.0, step=0.05,
                                                                 label='Scale Factor',
                                                                 value=modules.config.default_sd_upscale_scale_factor)
+                                    sd_denoising_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.001,
+                                                                       label='Denoising Strength',
+                                                                       value=modules.config.default_sd_upscale_denoising_strength)
                                     sd_upscaler = gr.Dropdown(label='Upscaler',
                                                              choices=modules.sd_upscale.DEFAULT_UPSCALERS,
                                                              value=modules.config.default_sd_upscale_upscaler)
@@ -1024,7 +1027,7 @@ with shared.gradio_root:
 
         ctrls += [base_model, refiner_model, refiner_switch] + lora_ctrls
         ctrls += [input_image_checkbox, current_tab]
-        ctrls += [uov_method, uov_input_image, sd_upscale_checkbox, sd_tile_overlap, sd_scale_factor, sd_upscaler]
+        ctrls += [uov_method, uov_input_image, sd_upscale_checkbox, sd_tile_overlap, sd_scale_factor, sd_denoising_strength, sd_upscaler]
         ctrls += [outpaint_selections, inpaint_input_image, inpaint_additional_prompt, inpaint_mask_image]
         ctrls += [disable_preview, disable_intermediate_results, disable_seed_increment, black_out_nsfw]
         ctrls += [adm_scaler_positive, adm_scaler_negative, adm_scaler_end, adaptive_cfg, clip_skip]


### PR DESCRIPTION
## Summary
- fetch available upscaler models on load
- expose denoising strength slider for SD upscale
- save default denoising strength in config
- pass denoising strength through async worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e03c1667c832b8d3006e07739fa6b