### PR TITLE
Fix missing ui_common import

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,7 @@ import modules.meta_parser
 import args_manager
 import copy
 import modules.sd_upscale
+from modules import ui_common
 import launch
 from extras.inpaint_mask import SAMOptions
 from modules.private_logger import get_current_html_path


### PR DESCRIPTION
## Summary
- import `ui_common` in `webui.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e11c3b140832bb185e8c2b11c768d