### PR TITLE
Ensure upscaler is downloaded on startup

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -111,6 +111,9 @@ def download_models(default_model, checkpoint_downloads, embeddings_downloads, l
         file_name='pytorch_model.bin'
     )
 
+    # Ensure the default upscale model is available
+    config.downloading_upscale_model()
+
     if args.disable_preset_download:
         print('Skipped model download.')
         return default_model, checkpoint_downloads


### PR DESCRIPTION
## Summary
- trigger download of the default upscaler model when downloading preset models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e165c1310832b9a68aca08f44d814