### PR TITLE
Ensure single image generation when SD Upscale is active

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -178,6 +178,10 @@ class AsyncTask:
                     enhance_inpaint_erode_or_dilate,
                     enhance_mask_invert
                 ])
+
+        if self.sd_upscale_checkbox and self.image_number != 1:
+            print('[Future-Sd-Upscale] Forcing image_number to 1')
+            self.image_number = 1
         self.should_enhance = self.enhance_checkbox and (self.enhance_uov_method != disabled.casefold() or len(self.enhance_ctrls) > 0)
         self.images_to_enhance_count = 0
         self.enhance_stats = {}

--- a/webui.py
+++ b/webui.py
@@ -234,10 +234,6 @@ with shared.gradio_root:
                                             modules.sd_upscale.reload_upscalers,
                                             lambda: {"choices": modules.sd_upscale.DEFAULT_UPSCALERS}
                                         )
-                                sd_upscale_checkbox.change(lambda x: gr.update(visible=x),
-                                                           inputs=sd_upscale_checkbox,
-                                                           outputs=sd_upscale_panel,
-                                                           queue=False, show_progress=False)
                                 gr.HTML('<a href="https://github.com/lllyasviel/Fooocus/discussions/390" target="_blank">\U0001F4D4 Documentation</a>')
                     with gr.Tab(label='Image Prompt', id='ip_tab') as ip_tab:
                         with gr.Row():
@@ -603,6 +599,11 @@ with shared.gradio_root:
                     shared.gradio_root.load(lambda x: None, inputs=aspect_ratios_selection, queue=False, show_progress=False, _js='(x)=>{refresh_aspect_ratios_label(x);}')
 
                 image_number = gr.Slider(label='Image Number', minimum=1, maximum=modules.config.default_max_image_number, step=1, value=modules.config.default_image_number)
+                sd_upscale_checkbox.change(
+                    lambda x, y: (gr.update(visible=x), gr.update(value=1 if x else y)),
+                    inputs=[sd_upscale_checkbox, image_number],
+                    outputs=[sd_upscale_panel, image_number],
+                    queue=False, show_progress=False)
 
                 with gr.Accordion(label='Advanced', open=False):
 


### PR DESCRIPTION
## Summary
- enforce `image_number=1` in `AsyncTask` when SD Upscale is selected
- update web UI so toggling SD Upscale also changes the Image Number slider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1b01c97c832b924fb59c08e07558