### PR TITLE
Fix DOM null checks in viewer and localization scripts

### DIFF
--- a/javascript/localization.js
+++ b/javascript/localization.js
@@ -81,12 +81,14 @@ function refresh_style_localization() {
 }
 
 function refresh_aspect_ratios_label(value) {
-    label = document.querySelector('#aspect_ratios_accordion div span');
-    translation = getTranslation("Aspect Ratios");
+    let label = document.querySelector('#aspect_ratios_accordion div span');
+    let translation = getTranslation("Aspect Ratios");
     if (typeof translation == "undefined") {
         translation = "Aspect Ratios";
     }
-    label.textContent = translation + " " + htmlDecode(value);
+    if (label) {
+        label.textContent = translation + " " + htmlDecode(value);
+    }
 }
 
 function localizeWholePage() {

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -112,13 +112,16 @@ onUiLoaded(async () => {
         });
     }
 
-    document.querySelector('.style_selections').addEventListener('focusout', function (event) {
-        setTimeout(() => {
-            if (!this.contains(document.activeElement)) {
-                on_style_selection_blur();
-            }
-        }, 200);
-    });
+    let styleSelections = document.querySelector('.style_selections');
+    if (styleSelections) {
+        styleSelections.addEventListener('focusout', function (event) {
+            setTimeout(() => {
+                if (!this.contains(document.activeElement)) {
+                    on_style_selection_blur();
+                }
+            }, 200);
+        });
+    }
 
     let inputs = document.querySelectorAll('.lora_weight input[type="range"]');
 


### PR DESCRIPTION
## Summary
- guard against missing elements before adding event listeners in `viewer.js`
- prevent errors when aspect ratio label is absent in `localization.js`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e23cc1990832b8c3b2ad7cb7c6dba