### PR TITLE
Add download button for latest image

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -485,3 +485,7 @@ div:has(> #positive_prompt) {
   cursor: pointer;
   box-sizing: border-box;
 }
+
+.download_button {
+  width: 100%;
+}

--- a/modules/util.py
+++ b/modules/util.py
@@ -18,6 +18,9 @@ import modules.config
 import modules.sdxl_styles
 from modules.flags import Performance
 
+# Default output directory for generated images
+default_output_dir = modules.config.path_outputs
+
 # Cache to store wildcard file contents along with last modification time
 _wildcard_cache = {}
 
@@ -200,6 +203,24 @@ def generate_temp_filename(folder='./outputs/', extension='png'):
     filename = f"{time_string}_{random_number}.{extension}"
     result = os.path.join(folder, date_string, filename)
     return date_string, os.path.abspath(result), filename
+
+
+def get_latest_output_image() -> str | None:
+    """Return the most recently modified image under the default output directory."""
+    latest_file = None
+    latest_time = -1.0
+    for root, _, files in os.walk(default_output_dir):
+        for name in files:
+            if name.lower().endswith(('.png', '.jpg', '.jpeg', '.webp')):
+                file_path = os.path.join(root, name)
+                try:
+                    mtime = os.path.getmtime(file_path)
+                    if mtime > latest_time:
+                        latest_time = mtime
+                        latest_file = file_path
+                except OSError:
+                    continue
+    return latest_file
 
 
 def sha256(filename, use_addnet_hash=False, length=HASH_SHA256_LENGTH):

--- a/webui.py
+++ b/webui.py
@@ -22,7 +22,7 @@ from extras.inpaint_mask import SAMOptions
 from modules.private_logger import get_current_html_path
 from modules.ui_gradio_extensions import reload_javascript
 from modules.auth import auth_enabled, check_auth
-from modules.util import is_json
+from modules.util import is_json, get_latest_output_image
 
 shared.prompt_styles = styles.StyleDatabase(["styles.csv", "styles_integrated.csv"])
 
@@ -233,6 +233,17 @@ with shared.gradio_root:
                                             [sd_upscaler],
                                             modules.sd_upscale.reload_upscalers,
                                             lambda: {"choices": modules.sd_upscale.DEFAULT_UPSCALERS}
+                                        )
+                                    with gr.Row():
+                                        download_button = gr.Button(
+                                            value='Descargar \u2B07\uFE0F',
+                                            elem_id='download-btn',
+                                            elem_classes='download_button'
+                                        )
+                                        download_file = gr.File(
+                                            interactive=False,
+                                            visible=False,
+                                            elem_id='download-file'
                                         )
                                 gr.HTML('<a href="https://github.com/lllyasviel/Fooocus/discussions/390" target="_blank">\U0001F4D4 Documentation</a>')
                     with gr.Tab(label='Image Prompt', id='ip_tab') as ip_tab:
@@ -1157,6 +1168,8 @@ with shared.gradio_root:
             enhance_input_image.upload(lambda: gr.update(value=True), outputs=enhance_checkbox, queue=False, show_progress=False) \
                 .then(trigger_auto_describe, inputs=[describe_methods, enhance_input_image, prompt, describe_apply_styles],
                       outputs=[prompt, style_selections], show_progress=True, queue=True)
+
+        download_button.click(lambda: get_latest_output_image(), outputs=download_file, queue=False, show_progress=False)
 
 def dump_default_english_config():
     from modules.localization import dump_english_config


### PR DESCRIPTION
## Summary
- expose default output directory in util and add `get_latest_output_image`
- place a new `Descargar ⬇️` button below the upscaler settings
- clicking the button retrieves the most recent file under `outputs` for download
- style the button to stretch across its row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e34e9f868832b9dd872b3a869c417