### PR TITLE
Extend tag autocomplete to negative prompt

### DIFF
--- a/javascript/tag_autocomplete.js
+++ b/javascript/tag_autocomplete.js
@@ -364,9 +364,13 @@
 
     function init(){
         if(!ENABLED) return;
-        const area = document.querySelector('#positive_prompt textarea');
-        if(!area) return;
-        Promise.all([loadTags(), loadChants()]).then(()=>attach(area));
+        const positiveArea = document.querySelector('#positive_prompt textarea');
+        const negativeArea = document.querySelector('#negative_prompt textarea');
+        if(!positiveArea && !negativeArea) return;
+        Promise.all([loadTags(), loadChants()]).then(()=>{
+            if(positiveArea) attach(positiveArea);
+            if(negativeArea) attach(negativeArea);
+        });
     }
 
     if(window.onUiLoaded){


### PR DESCRIPTION
## Summary
- extend the tag autocomplete initialization so it also applies to the negative prompt field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e364ab23c832bb406f50ee0b74c68