### PR TITLE
Add debug prints for image paths

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -419,7 +419,9 @@ def worker():
             d.append(('Metadata Scheme', 'metadata_scheme',
                       async_task.metadata_scheme.value if async_task.save_metadata_to_images else async_task.save_metadata_to_images))
             d.append(('Version', 'version', 'Fooocus v' + fooocus_version.version))
-            img_paths.append(log(x, d, metadata_parser, async_task.output_format, task, persist_image))
+            path = log(x, d, metadata_parser, async_task.output_format, task, persist_image)
+            print(f"DEBUG: Saved image path {path}")
+            img_paths.append(path)
 
         return img_paths
 

--- a/webui.py
+++ b/webui.py
@@ -78,6 +78,7 @@ def generate_clicked(task: worker.AsyncTask):
                 if not args_manager.args.disable_enhance_output_sorting:
                     product = sort_enhance_images(product, task)
 
+                print("DEBUG: Returning final images", product)
                 yield gr.update(visible=False), \
                     gr.update(visible=False), \
                     gr.update(visible=False), \


### PR DESCRIPTION
## Summary
- add print statements for debugging the saved image paths
- log final images returned to Gradio

## Testing
- `python -m unittest tests/test_utils.py`
- `python -m unittest tests/test_extra_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684e39c61500832b8c73111568b1e997