### PR TITLE
Fix download button visibility

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -70,11 +70,12 @@ def generate_clicked(task: worker.AsyncTask):
                     gr.update(), \
                     gr.update()
             if flag == 'results':
+                last_img = product[-1] if isinstance(product, list) else product
                 yield gr.update(visible=True), \
                     gr.update(), \
                     gr.update(), \
                     gr.update(), \
-                    gr.update()
+                    gr.update(value=last_img, visible=True)
             if flag == 'finish':
                 if not args_manager.args.disable_enhance_output_sorting:
                     product = sort_enhance_images(product, task)


### PR DESCRIPTION
## Summary
- ensure download button becomes visible for each image preview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684e42a20d2c832b89ca0293d06e8132