### PR TITLE
Add simple download button

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -11,6 +11,10 @@ from modules.meta_parser import MetadataParser, get_exif
 from modules.util import generate_temp_filename
 
 log_cache = {}
+last_saved_image_path = None
+
+def get_last_saved_image():
+    return last_saved_image_path
 
 
 def get_current_html_path(output_format=None, folder=None):
@@ -36,6 +40,7 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
     parsed_parameters = metadata_parser.to_string(metadata.copy()) if metadata_parser is not None else ''
     image = Image.fromarray(img)
 
+    global last_saved_image_path
     if output_format == OutputFormat.PNG.value:
         if parsed_parameters != '':
             pnginfo = PngInfo()
@@ -50,6 +55,8 @@ def log(img, metadata, metadata_parser: MetadataParser | None = None, output_for
         image.save(local_temp_filename, quality=95, lossless=False, exif=get_exif(parsed_parameters, metadata_parser.get_scheme().value) if metadata_parser else Image.Exif())
     else:
         image.save(local_temp_filename)
+
+    last_saved_image_path = local_temp_filename
 
     if args_manager.args.disable_image_log:
         return local_temp_filename

--- a/webui.py
+++ b/webui.py
@@ -186,6 +186,8 @@ with shared.gradio_root:
                     load_parameter_button = gr.Button(label="Load Parameters", value="Load Parameters", elem_classes='type_row', elem_id='load_parameter_button', visible=False)
                     skip_button = gr.Button(label="Skip", value="Skip", elem_classes='type_row_half', elem_id='skip_button', visible=False)
                     stop_button = gr.Button(label="Stop", value="Stop", elem_classes='type_row_half', elem_id='stop_button', visible=False)
+                    download_button = gr.Button(label="Download Last Image", elem_id='download_last_button')
+                    download_file = gr.File(interactive=False, visible=True, elem_id='download_last_file')
 
                     def stop_clicked(currentTask):
                         import ldm_patched.modules.model_management as model_management
@@ -203,6 +205,12 @@ with shared.gradio_root:
 
                     stop_button.click(stop_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False, _js='cancelGenerateForever')
                     skip_button.click(skip_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False)
+
+                    def download_last_image():
+                        import modules.private_logger as pl
+                        return pl.get_last_saved_image()
+
+                    download_button.click(download_last_image, outputs=download_file, queue=False, show_progress=False)
             with gr.Row(elem_classes='advanced_check_row'):
                 input_image_checkbox = gr.Checkbox(label='Input Image', value=modules.config.default_image_prompt_checkbox, container=False, elem_classes='min_check')
                 enhance_checkbox = gr.Checkbox(label='Enhance', value=modules.config.default_enhance_checkbox, container=False, elem_classes='min_check')


### PR DESCRIPTION
## Summary
- track last saved image path
- provide a download button to fetch the latest image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684e4aa0181c832bad42b54a311de71b