### PR TITLE
Update download button placement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,6 +136,11 @@ div:has(> #positive_prompt) {
     margin-bottom: 2px;
 }
 
+/* Hide internal file component used for downloading the last image */
+#download_last_file {
+  display: none !important;
+}
+
 /* ratio text with small icon */
 
 /* visual icon container */

--- a/webui.py
+++ b/webui.py
@@ -186,8 +186,6 @@ with shared.gradio_root:
                     load_parameter_button = gr.Button(label="Load Parameters", value="Load Parameters", elem_classes='type_row', elem_id='load_parameter_button', visible=False)
                     skip_button = gr.Button(label="Skip", value="Skip", elem_classes='type_row_half', elem_id='skip_button', visible=False)
                     stop_button = gr.Button(label="Stop", value="Stop", elem_classes='type_row_half', elem_id='stop_button', visible=False)
-                    download_button = gr.Button(label="Download Last Image", elem_id='download_last_button')
-                    download_file = gr.File(interactive=False, visible=True, elem_id='download_last_file')
 
                     def stop_clicked(currentTask):
                         import ldm_patched.modules.model_management as model_management
@@ -206,11 +204,6 @@ with shared.gradio_root:
                     stop_button.click(stop_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False, _js='cancelGenerateForever')
                     skip_button.click(skip_clicked, inputs=currentTask, outputs=currentTask, queue=False, show_progress=False)
 
-                    def download_last_image():
-                        import modules.private_logger as pl
-                        return pl.get_last_saved_image()
-
-                    download_button.click(download_last_image, outputs=download_file, queue=False, show_progress=False)
             with gr.Row(elem_classes='advanced_check_row'):
                 input_image_checkbox = gr.Checkbox(label='Input Image', value=modules.config.default_image_prompt_checkbox, container=False, elem_classes='min_check')
                 enhance_checkbox = gr.Checkbox(label='Enhance', value=modules.config.default_enhance_checkbox, container=False, elem_classes='min_check')
@@ -243,6 +236,14 @@ with shared.gradio_root:
                                             modules.sd_upscale.reload_upscalers,
                                             lambda: {"choices": modules.sd_upscale.DEFAULT_UPSCALERS}
                                         )
+                                        download_button = gr.Button(label="Download Last Image", elem_id='download_last_button')
+                                        download_file = gr.File(interactive=False, visible=False, elem_id='download_last_file')
+
+                                        def download_last_image():
+                                            import modules.private_logger as pl
+                                            return pl.get_last_saved_image()
+
+                                        download_button.click(download_last_image, outputs=download_file, queue=False, show_progress=False)
                                 gr.HTML('<a href="https://github.com/lllyasviel/Fooocus/discussions/390" target="_blank">\U0001F4D4 Documentation</a>')
                     with gr.Tab(label='Image Prompt', id='ip_tab') as ip_tab:
                         with gr.Row():


### PR DESCRIPTION
## Summary
- move 'Download Last Image' button to the SD Upscale panel
- hide the underlying file component so only the button is visible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684e4e50decc832b9541fa88a84d914d