### PR TITLE
Fix final display for SD Upscale and remove download

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,10 +136,6 @@ div:has(> #positive_prompt) {
     margin-bottom: 2px;
 }
 
-/* Hide internal file component used for downloading the last image */
-#download_last_file {
-  display: none !important;
-}
 
 /* ratio text with small icon */
 

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -936,6 +936,15 @@ def worker():
                 uov_input_image_path = log(async_task.uov_input_image, d, output_format=async_task.output_format)
                 yield_result(async_task, uov_input_image_path, 100, async_task.black_out_nsfw, False,
                              do_not_show_finished_images=True)
+                # Display the final result once upscale completes.
+                yield_result(
+                    async_task,
+                    uov_input_image_path,
+                    100,
+                    async_task.black_out_nsfw,
+                    False,
+                    do_not_show_finished_images=False,
+                )
                 raise EarlyReturnException
         if (async_task.current_tab == 'inpaint' or (
                 async_task.current_tab == 'ip' and async_task.mixing_image_prompt_and_inpaint)) \

--- a/webui.py
+++ b/webui.py
@@ -236,14 +236,6 @@ with shared.gradio_root:
                                             modules.sd_upscale.reload_upscalers,
                                             lambda: {"choices": modules.sd_upscale.DEFAULT_UPSCALERS}
                                         )
-                                        download_button = gr.Button(value="\u2B07\uFE0F", label="Download Last Image", elem_id='download_last_button')
-                                        download_file = gr.File(interactive=False, visible=False, elem_id='download_last_file')
-
-                                        def download_last_image():
-                                            import modules.private_logger as pl
-                                            return pl.get_last_saved_image()
-
-                                        download_button.click(download_last_image, outputs=download_file, queue=False, show_progress=False)
                                 gr.HTML('<a href="https://github.com/lllyasviel/Fooocus/discussions/390" target="_blank">\U0001F4D4 Documentation</a>')
                     with gr.Tab(label='Image Prompt', id='ip_tab') as ip_tab:
                         with gr.Row():


### PR DESCRIPTION
## Summary
- show the final SD Upscale result after processing
- drop the unused "Download Last Image" button and hidden file component
- remove the related CSS rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6735bd98832bb984076b95d9ba2c