### PR TITLE
Enable per-tile denoising for SD upscale

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -624,7 +624,9 @@ def worker():
                 overlap=int(async_task.sd_upscale_tile_overlap),
                 scale_factor=float(async_task.sd_upscale_scale_factor),
                 upscaler_name=async_task.sd_upscale_upscaler,
-                progress_callback=upscale_cb
+                progress_callback=upscale_cb,
+                prompt=async_task.prompt,
+                denoising_strength=float(async_task.sd_upscale_denoising_strength),
             )
             uov_input_image = np.array(pil_img)
         if '1.5x' in uov_method:
@@ -929,6 +931,8 @@ def worker():
                     scale_factor=float(async_task.sd_upscale_scale_factor),
                     upscaler_name=async_task.sd_upscale_upscaler,
                     progress_callback=upscale_cb,
+                    prompt=async_task.prompt,
+                    denoising_strength=float(async_task.sd_upscale_denoising_strength),
                 )
                 async_task.uov_input_image = np.array(pil_img)
                 progressbar(async_task, 100, 'Saving image to system ...')


### PR DESCRIPTION
## Summary
- add `apply_denoising` helper that runs Img2Img on a tile
- allow `upscale_image` to take prompt and denoising strength
- apply denoising to each tile if strength is >0
- plumb new arguments through `async_worker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efef62aac832bb160a7ee3139b52f