### PR TITLE
Fix AsyncTask prompt parsing

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -32,6 +32,20 @@ class AsyncTask:
         self.generate_image_grid = args.pop()
         self.prompt = args.pop()
         self.negative_prompt = args.pop()
+
+        # Ensure prompt fields are strings to avoid attribute errors when
+        # processing unexpected types.
+        if not isinstance(self.prompt, str):
+            if isinstance(self.prompt, list):
+                self.prompt = ", ".join(map(str, self.prompt))
+            else:
+                self.prompt = str(self.prompt)
+
+        if not isinstance(self.negative_prompt, str):
+            if isinstance(self.negative_prompt, list):
+                self.negative_prompt = ", ".join(map(str, self.negative_prompt))
+            else:
+                self.negative_prompt = str(self.negative_prompt)
         self.style_selections = args.pop()
         self.csv_styles = args.pop()
         if self.csv_styles is None:


### PR DESCRIPTION
## Summary
- handle unexpected types for prompts in AsyncTask
- the tests pass after installing numpy, opencv, and pillow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f600148f0832bb92ad5e504d4d4de