### PR TITLE
Fix SD Upscale defaults

### DIFF
--- a/modules/sd_upscale.py
+++ b/modules/sd_upscale.py
@@ -115,8 +115,8 @@ def upscale_image(
         image: Image.Image,
         overlap: int,
         scale_factor: float,
-        tile_size: int = 384,
-        upscaler_name: str = "RealESRGAN_x4plus",
+        tile_size: int = 512,
+        upscaler_name: str = "None",
         batch_size: int = 4,
         progress_callback=None,
         prompt: str = "",
@@ -138,7 +138,7 @@ def upscale_image(
     scale_factor : float
         Overall scaling factor for the image.
     tile_size : int, optional
-        Size of each tile processed individually, by default ``384``.
+        Size of each tile processed individually, by default ``512``.
     upscaler_name : str, optional
         Name of the ESRGAN model to use. ``"None"`` disables the model and only
         performs a Lanczos resize.


### PR DESCRIPTION
## Summary
- update SD upscale defaults
- set default tile size to 512
- don't force a specific upscaler model by default

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f77779fa8832bb893956e325beb7d