### PR TITLE
Allow seed in upscale denoising

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -624,7 +624,10 @@ def worker():
                 overlap=int(async_task.sd_upscale_tile_overlap),
                 scale_factor=float(async_task.sd_upscale_scale_factor),
                 upscaler_name=async_task.sd_upscale_upscaler,
-                progress_callback=upscale_cb
+                progress_callback=upscale_cb,
+                prompt=async_task.prompt,
+                denoising_strength=float(async_task.sd_upscale_denoising_strength),
+                seed=async_task.seed
             )
             uov_input_image = np.array(pil_img)
         if '1.5x' in uov_method:
@@ -929,6 +932,9 @@ def worker():
                     scale_factor=float(async_task.sd_upscale_scale_factor),
                     upscaler_name=async_task.sd_upscale_upscaler,
                     progress_callback=upscale_cb,
+                    prompt=async_task.prompt,
+                    denoising_strength=float(async_task.sd_upscale_denoising_strength),
+                    seed=async_task.seed
                 )
                 async_task.uov_input_image = np.array(pil_img)
                 progressbar(async_task, 100, 'Saving image to system ...')


### PR DESCRIPTION
## Summary
- allow specifying a seed for `apply_denoising`
- expose `seed` parameter in `upscale_image`
- pass user prompt, denoising strength and seed from `async_worker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7d7818dc832bbfedcbda0c265093