### PR TITLE
Add image zoom functionality

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -490,3 +490,7 @@ div:has(> #positive_prompt) {
   cursor: pointer;
   box-sizing: border-box;
 }
+
+#lightboxModal img.zoomable{cursor: grab;transition: transform 0.05s ease-out;}
+#lightboxModal img.zoomable:active{cursor: grabbing;}
+

--- a/javascript/imageviewer.js
+++ b/javascript/imageviewer.js
@@ -1,13 +1,19 @@
 // From A1111
 
 function closeModal() {
-    gradioApp().getElementById("lightboxModal").style.display = "none";
+    const modal = gradioApp().getElementById("lightboxModal");
+    const img = gradioApp().getElementById("modalImage");
+    if (img) {
+        img.style.transform = "";
+    }
+    modal.style.display = "none";
 }
 
 function showModal(event) {
     const source = event.target || event.srcElement;
     const modalImage = gradioApp().getElementById("modalImage");
     const lb = gradioApp().getElementById("lightboxModal");
+    modalImage.style.transform = "";
     modalImage.src = source.src;
     if (modalImage.style.display === 'none') {
         lb.style.setProperty('background-image', 'url(' + source.src + ')');

--- a/javascript/zoomimage.js
+++ b/javascript/zoomimage.js
@@ -1,0 +1,75 @@
+onUiLoaded(() => {
+    const modal = document.getElementById('lightboxModal');
+    const img = document.getElementById('modalImage');
+    if (!modal || !img) {
+        return;
+    }
+
+    img.classList.add('zoomable');
+
+    let scale = 1.0;
+    let panX = 0;
+    let panY = 0;
+    let startX = 0;
+    let startY = 0;
+    let dragging = false;
+
+    function applyTransform() {
+        img.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    }
+
+    function resetTransform() {
+        scale = 1.0;
+        panX = 0;
+        panY = 0;
+        img.style.transform = '';
+    }
+
+    img.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const rect = img.getBoundingClientRect();
+        const offsetX = e.clientX - rect.left;
+        const offsetY = e.clientY - rect.top;
+        const prevScale = scale;
+        const delta = e.deltaY > 0 ? -0.1 : 0.1;
+        scale = Math.min(5, Math.max(0.2, scale + delta));
+        panX += offsetX - offsetX * (scale / prevScale);
+        panY += offsetY - offsetY * (scale / prevScale);
+        applyTransform();
+    });
+
+    img.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) return;
+        dragging = true;
+        startX = e.clientX;
+        startY = e.clientY;
+        img.style.cursor = 'grabbing';
+    });
+
+    document.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        panX += e.clientX - startX;
+        panY += e.clientY - startY;
+        startX = e.clientX;
+        startY = e.clientY;
+        applyTransform();
+    });
+
+    document.addEventListener('mouseup', () => {
+        dragging = false;
+        img.style.cursor = '';
+    });
+
+    modal.addEventListener('click', (e) => {
+        if (e.target === modal) {
+            resetTransform();
+        }
+    });
+
+    // reset when modal closes via code
+    const originalClose = closeModal;
+    closeModal = function() {
+        resetTransform();
+        originalClose();
+    };
+});

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -32,6 +32,7 @@ def javascript_html():
     edit_attention_js_path = webpath('javascript/edit-attention.js')
     viewer_js_path = webpath('javascript/viewer.js')
     image_viewer_js_path = webpath('javascript/imageviewer.js')
+    zoom_image_js_path = webpath('javascript/zoomimage.js')
     tag_autocomplete_js_path = webpath('javascript/tag_autocomplete.js')
     tag_dir = os.path.join(script_path, 'a1111-sd-webui-tagcomplete', 'tags')
     tag_files = [os.path.join('a1111-sd-webui-tagcomplete', 'tags', f) for f in os.listdir(tag_dir) if f.endswith('.csv')]
@@ -57,6 +58,7 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{edit_attention_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{image_viewer_js_path}"></script>\n'
+    head += f'<script type="text/javascript" src="{zoom_image_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{tag_autocomplete_js_path}"></script>\n'
     head += f'<script type="text/javascript">window.tag_csv_files = {tag_files_json};</script>\n'
     head += f'<script type="text/javascript">window.chant_json_files = {chant_files_json};</script>\n'


### PR DESCRIPTION
## Summary
- enable zoom/pan on lightbox images via new `zoomimage.js`
- reset zoom state when closing viewer
- include new script in the Gradio template
- style zoomable images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9279256c832b9ff1fa8e2484dad2