### PR TITLE
Add simple LoRA card UI

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -1,0 +1,59 @@
+import os
+from modules import config, util, shared
+
+LORA_EXTENSIONS = {'.safetensors', '.ckpt', '.pt'}
+
+
+def list_loras():
+    files = []
+    for folder in config.paths_loras:
+        if not os.path.isdir(folder):
+            continue
+        for name in os.listdir(folder):
+            ext = os.path.splitext(name)[1].lower()
+            if ext in LORA_EXTENSIONS:
+                files.append(os.path.join(folder, name))
+    return sorted(files)
+
+
+def find_preview(path):
+    base, _ = os.path.splitext(path)
+    for ext in ['.png', '.jpg', '.jpeg', '.webp']:
+        cand = base + ext
+        if os.path.exists(cand):
+            return cand
+        cand = base + '.preview' + ext
+        if os.path.exists(cand):
+            return cand
+    return None
+
+
+def generate_cards():
+    card_tpl = shared.html('extra-networks-card.html')
+    copy_tpl = shared.html('extra-networks-copy-path-button.html')
+    meta_tpl = shared.html('extra-networks-metadata-button.html')
+    edit_tpl = shared.html('extra-networks-edit-item-button.html')
+    cards = []
+    for filepath in list_loras():
+        name = os.path.splitext(os.path.basename(filepath))[0]
+        preview = find_preview(filepath)
+        if preview:
+            preview_html = f'<img src="file={preview}" class="preview">'
+        else:
+            preview_html = ''
+        prompt = f"\"<lora:{name}:1>\""
+        onclick = f"cardClicked('advanced', {prompt}, '' , false);"
+        args = {
+            'style': '',
+            'card_clicked': onclick,
+            'name': name,
+            'sort_keys': '',
+            'background_image': preview_html,
+            'copy_path_button': copy_tpl.format(filename=filepath),
+            'metadata_button': meta_tpl.format(extra_networks_tabname='lora'),
+            'edit_button': edit_tpl.format(tabname='advanced', extra_networks_tabname='lora'),
+            'description': '',
+            'search_terms': '',
+        }
+        cards.append(card_tpl.format(**args))
+    return '\n'.join(cards)

--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -34,6 +34,7 @@ def javascript_html():
     image_viewer_js_path = webpath('javascript/imageviewer.js')
     zoom_image_js_path = webpath('javascript/zoomimage.js')
     tag_autocomplete_js_path = webpath('javascript/tag_autocomplete.js')
+    extra_networks_js_path = webpath('modules/NewLoraSystem/javascrypt/extraNetworks.js')
     tag_dir = os.path.join(script_path, 'a1111-sd-webui-tagcomplete', 'tags')
     tag_files = [os.path.join('a1111-sd-webui-tagcomplete', 'tags', f) for f in os.listdir(tag_dir) if f.endswith('.csv')]
     chant_files = [os.path.join('a1111-sd-webui-tagcomplete', 'tags', f) for f in os.listdir(tag_dir) if f.endswith('-chants.json')]
@@ -60,6 +61,7 @@ def javascript_html():
     head += f'<script type="text/javascript" src="{image_viewer_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{zoom_image_js_path}"></script>\n'
     head += f'<script type="text/javascript" src="{tag_autocomplete_js_path}"></script>\n'
+    head += f'<script type="text/javascript" src="{extra_networks_js_path}"></script>\n'
     head += f'<script type="text/javascript">window.tag_csv_files = {tag_files_json};</script>\n'
     head += f'<script type="text/javascript">window.chant_json_files = {chant_files_json};</script>\n'
     head += f'<script type="text/javascript">window.tac_user_config = {tac_cfg};</script>\n'
@@ -73,7 +75,9 @@ def javascript_html():
 
 def css_html():
     style_css_path = webpath('css/style.css')
-    head = f'<link rel="stylesheet" property="stylesheet" href="{style_css_path}">'
+    extra_css_path = webpath('modules/NewLoraSystem/css/style.css')
+    head = f'<link rel="stylesheet" property="stylesheet" href="{style_css_path}">' \
+           f'\n<link rel="stylesheet" property="stylesheet" href="{extra_css_path}">' 
     return head
 
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -31,6 +31,51 @@ LORAS_PROMPT_PATTERN = re.compile(r"(<lora:([^:]+):([+-]?(?:\d+(?:\.\d*)?|\.\d+)
 HASH_SHA256_LENGTH = 10
 
 
+class MassFileLister:
+    """Simple filesystem cache for modification times used by extra networks."""
+
+    def __init__(self):
+        self._cache = {}
+
+    def mctime(self, path: str):
+        """Return modification and creation times for a path."""
+        try:
+            stat = os.stat(path)
+            mtime, ctime = int(stat.st_mtime), int(stat.st_ctime)
+            self._cache[path] = (mtime, ctime, True)
+            return mtime, ctime
+        except OSError:
+            self._cache[path] = (0, 0, False)
+            return 0, 0
+
+    def exists(self, path: str) -> bool:
+        if path in self._cache:
+            cached = self._cache[path]
+            if cached[2]:
+                if os.path.exists(path):
+                    return True
+                self._cache[path] = (0, 0, False)
+                return False
+            return False
+        exists = os.path.exists(path)
+        if exists:
+            stat = os.stat(path)
+            self._cache[path] = (int(stat.st_mtime), int(stat.st_ctime), True)
+        else:
+            self._cache[path] = (0, 0, False)
+        return exists
+
+    def reset(self):
+        self._cache.clear()
+
+    def update_file_entry(self, path: str):
+        self._cache.pop(path, None)
+        if os.path.exists(path):
+            stat = os.stat(path)
+            self._cache[path] = (int(stat.st_mtime), int(stat.st_ctime), True)
+
+
+
 def clear_wildcard_cache():
     """Clears the cached wildcard file contents."""
     _wildcard_cache.clear()

--- a/shared.py
+++ b/shared.py
@@ -1,2 +1,20 @@
 gradio_root = None
 prompt_styles = None
+
+import os
+
+_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def html(name: str) -> str:
+    """Return contents of an HTML template bundled with the repo."""
+    paths = [
+        os.path.join(_MODULE_DIR, "NewLoraSystem", "html", name),
+        os.path.join(_MODULE_DIR, "html", name),
+    ]
+    for path in paths:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read()
+    raise FileNotFoundError(name)
+

--- a/webui.py
+++ b/webui.py
@@ -23,6 +23,7 @@ from modules.private_logger import get_current_html_path
 from modules.ui_gradio_extensions import reload_javascript
 from modules.auth import auth_enabled, check_auth
 from modules.util import is_json
+from modules import simple_lora_ui
 
 shared.prompt_styles = styles.StyleDatabase(["styles.csv", "styles_integrated.csv"])
 
@@ -705,23 +706,17 @@ with shared.gradio_root:
                     refiner_model.change(lambda x: gr.update(visible=x != 'None'),
                                          inputs=refiner_model, outputs=refiner_switch, show_progress=False, queue=False)
 
+                lora_ctrls = []
                 with gr.Group():
-                    lora_ctrls = []
+                    from modules import simple_lora_ui
+                    lora_html = gr.HTML(simple_lora_ui.generate_cards(), elem_id='lora_cards')
 
-                    for i, (enabled, filename, weight) in enumerate(modules.config.default_loras):
-                        with gr.Row():
-                            lora_enabled = gr.Checkbox(label='Enable', value=enabled,
-                                                       elem_classes=['lora_enable', 'min_check'], scale=1)
-                            lora_model = gr.Dropdown(label=f'LoRA {i + 1}',
-                                                     choices=['None'] + modules.config.lora_filenames, value=filename,
-                                                     elem_classes='lora_model', scale=5)
-                            lora_weight = gr.Slider(label='Weight', minimum=modules.config.default_loras_min_weight,
-                                                    maximum=modules.config.default_loras_max_weight, step=0.01, value=weight,
-                                                    elem_classes='lora_weight', scale=5)
-                            lora_ctrls += [lora_enabled, lora_model, lora_weight]
+                    def refresh_loras():
+                        return gr.update(value=simple_lora_ui.generate_cards())
 
                 with gr.Row():
                     refresh_files = gr.Button(label='Refresh', value='\U0001f504 Refresh All Files', variant='secondary', elem_classes='refresh_button')
+                    refresh_files.click(fn=refresh_loras, outputs=lora_html, queue=False, show_progress=False)
 
             with gr.Tab(label='Styles'):
                 from modules import ui_prompt_styles as ui_styles


### PR DESCRIPTION
## Summary
- implement simple MassFileLister utility
- load html templates from shared.html
- generate lightweight LoRA card list in new `simple_lora_ui`
- load ExtraNetworks JS/CSS assets
- replace old LoRA dropdowns in UI with card list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850426f2dfc832ba02fccaed91f85c6