### PR TITLE
Add inline LoRA metadata

### DIFF
--- a/modules/NewLoraSystem/html/extra-networks-metadata-button.html
+++ b/modules/NewLoraSystem/html/extra-networks-metadata-button.html
@@ -1,4 +1,5 @@
 <div class="metadata-button card-button"
     title="Show internal metadata"
+    data-metadata="{metadata_json}"
     onclick="extraNetworksRequestMetadata(event, '{extra_networks_tabname}')">
 </div>

--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -611,6 +611,12 @@ function extraNetworksCopyCardPath(event) {
 }
 
 function extraNetworksRequestMetadata(event, extraPage) {
+    var inlineData = event.target.dataset.metadata;
+    if (inlineData) {
+        extraNetworksShowMetadata(inlineData);
+        event.stopPropagation();
+        return;
+    }
     var showError = function() {
         extraNetworksShowMetadata("there was an error getting metadata");
     };

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -1,7 +1,33 @@
 import os
 from modules import config, util, shared
+import json
+import html
+try:
+    import safetensors.torch as st
+except Exception:
+    st = None
 
 LORA_EXTENSIONS = {'.safetensors', '.ckpt', '.pt'}
+
+
+def read_metadata(path):
+    metadata = {}
+    if path.lower().endswith('.safetensors') and st is not None:
+        try:
+            with st.safe_open(path, framework="pt") as f:
+                metadata.update(f.metadata())
+        except Exception:
+            pass
+
+    json_path = os.path.splitext(path)[0] + '.json'
+    if os.path.exists(json_path):
+        try:
+            with open(json_path, 'r', encoding='utf8') as j:
+                metadata.update(json.load(j))
+        except Exception:
+            pass
+
+    return metadata
 
 
 def list_loras():
@@ -43,6 +69,8 @@ def generate_cards():
             preview_html = ''
         prompt = f"\"<lora:{name}:1>\""
         onclick = f"cardClicked('advanced', {prompt}, '' , false);"
+        metadata = read_metadata(filepath)
+        metadata_json = html.escape(json.dumps(metadata))
         args = {
             'style': '',
             'card_clicked': onclick,
@@ -50,7 +78,7 @@ def generate_cards():
             'sort_keys': '',
             'background_image': preview_html,
             'copy_path_button': copy_tpl.format(filename=filepath),
-            'metadata_button': meta_tpl.format(extra_networks_tabname='lora'),
+            'metadata_button': meta_tpl.format(extra_networks_tabname='lora', metadata_json=metadata_json),
             'edit_button': edit_tpl.format(tabname='advanced', extra_networks_tabname='lora'),
             'description': '',
             'search_terms': '',


### PR DESCRIPTION
## Summary
- add metadata reader to `simple_lora_ui`
- embed metadata JSON in card HTML
- show inline metadata in `extraNetworks.js`

## Testing
- `pip install safetensors numpy`
- `pytest -q` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68504a1e6160832b9b49214fc5755133