### PR TITLE
Add Lora tag helpers

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1667,3 +1667,15 @@ body.resizing .resize-handle {
 #quicksettings .gradio-slider span {
     padding-right: 5px;
 }
+
+.metadata-tags {
+    margin-top: 1em;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25em;
+}
+.metadata-tags span {
+    background: var(--button-secondary-background-fill);
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+}

--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -558,13 +558,53 @@ function extraNetworksFlattenMetadata(obj) {
     return result;
 }
 
-function extraNetworksShowMetadata(text) {
+function extractTags(freq){
+    const tags = {};
+    if(!freq) return [];
+    try{
+        for(const key of Object.keys(freq)){
+            const group = freq[key];
+            for(const tag of Object.keys(group)){
+                const cnt = parseInt(group[tag]);
+                tags[tag] = (tags[tag]||0)+cnt;
+            }
+        }
+    }catch(err){
+        console.error(err);
+    }
+    return Object.entries(tags).sort((a,b)=>b[1]-a[1]);
+}
+
+function addTagsToPrompt(tags, tabname){
+    const textarea = gradioApp().querySelector(`#${tabname}_prompt > label > textarea`);
+    if(!textarea) return;
+    updatePromptArea(tags, textarea);
+}
+
+function extraNetworksShowMetadata(text, tabname) {
     try {
         let parsed = JSON.parse(text);
         if (parsed && typeof parsed === 'object') {
+            const tags = extractTags(parsed['ss_tag_frequency']);
             parsed = extraNetworksFlattenMetadata(parsed);
             const table = createVisualizationTable(parsed, 0);
-            popup(table);
+            const container = document.createElement('div');
+            container.appendChild(table);
+            if(tags.length>0){
+                const list = document.createElement('div');
+                list.classList.add('metadata-tags');
+                tags.slice(0,20).forEach(t=>{
+                    const span = document.createElement('span');
+                    span.textContent = t[0];
+                    list.appendChild(span);
+                });
+                const btn = document.createElement('button');
+                btn.textContent = 'Use these tags in the prompt';
+                btn.addEventListener('click',()=>addTagsToPrompt(tags.map(t=>t[0]).join(', '), tabname));
+                container.appendChild(list);
+                container.appendChild(btn);
+            }
+            popup(container);
             return;
         }
     } catch (error) {
@@ -613,19 +653,23 @@ function extraNetworksCopyCardPath(event) {
 function extraNetworksRequestMetadata(event, extraPage) {
     var inlineData = event.target.dataset.metadata;
     if (inlineData) {
-        extraNetworksShowMetadata(inlineData);
+        var pane = event.target.closest('[id$="_cards"]');
+        var tabname = pane ? pane.id.split('_')[0] : 'txt2img';
+        extraNetworksShowMetadata(inlineData, tabname);
         event.stopPropagation();
         return;
     }
     var showError = function() {
-        extraNetworksShowMetadata("there was an error getting metadata");
+        extraNetworksShowMetadata("there was an error getting metadata", tabname);
     };
 
     var cardName = event.target.parentElement.parentElement.getAttribute("data-name");
+    var pane = event.target.closest('[id$="_cards"]');
+    var tabname = pane ? pane.id.split('_')[0] : 'txt2img';
 
     requestGet("./sd_extra_networks/metadata", {page: extraPage, item: cardName}, function(data) {
         if (data && data.metadata) {
-            extraNetworksShowMetadata(data.metadata);
+            extraNetworksShowMetadata(data.metadata, tabname);
         } else {
             showError();
         }

--- a/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
+++ b/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
@@ -55,6 +55,8 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
         self.edit_activation_text = None
         self.slider_preferred_weight = None
         self.edit_notes = None
+        self.button_add_tags = None
+        self.tags_text = None
 
     def save_lora_user_metadata(self, name, desc, sd_version, activation_text, preferred_weight, negative_text, notes):
         user_metadata = self.get_user_metadata(name)
@@ -123,11 +125,14 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
 
         tags = build_tags(metadata)
         gradio_tags = [(tag, str(count)) for tag, count in tags[0:24]]
+        tags_text = ", ".join([tag for tag, _ in tags])
 
         return [
             *values[0:5],
             item.get("sd_version", "Unknown"),
             gr.HighlightedText.update(value=gradio_tags, visible=True if tags else False),
+            tags_text,
+            gr.update(visible=True if tags else False),
             user_metadata.get('activation text', ''),
             float(user_metadata.get('preferred weight', 0.0)),
             user_metadata.get('negative text', ''),
@@ -166,6 +171,8 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
         self.create_default_editor_elems()
 
         self.taginfo = gr.HighlightedText(label="Training dataset tags")
+        self.button_add_tags = gr.Button('Use these tags in the prompt', visible=False)
+        self.tags_text = gr.Textbox(visible=False)
         self.edit_activation_text = gr.Text(label='Activation text', info="Will be added to prompt along with Lora")
         self.slider_preferred_weight = gr.Slider(label='Preferred weight', info="Set to 0 to disable", minimum=0.0, maximum=2.0, step=0.01)
         self.edit_negative_text = gr.Text(label='Negative prompt', info="Will be added to negative prompts")
@@ -192,6 +199,14 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
 
         self.taginfo.select(fn=select_tag, inputs=[self.edit_activation_text], outputs=[self.edit_activation_text], show_progress=False)
 
+        self.button_add_tags.click(
+            fn=None,
+            _js=f"function(){addTagsToPrompt(gradioApp().querySelector('#{self.tags_text.elem_id} textarea').value, '{self.tabname}')}",
+            inputs=[],
+            outputs=[],
+            show_progress=False,
+        )
+
         self.create_default_buttons()
 
         viewed_components = [
@@ -202,6 +217,8 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
             self.edit_notes,
             self.select_sd_version,
             self.taginfo,
+            self.tags_text,
+            self.button_add_tags,
             self.edit_activation_text,
             self.slider_preferred_weight,
             self.edit_negative_text,


### PR DESCRIPTION
## Summary
- expose tag helper controls in the Lora metadata editor
- allow copying dataset tags to the main prompt
- visualise tags in metadata popup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685052754968832bb732026e2db334b1