### PR TITLE
Fix missing shared import in simple_lora_ui

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -2,7 +2,8 @@ import os
 from io import BytesIO
 from typing import List
 from PIL import Image
-from modules import config, util, shared
+from modules import config, util
+import shared
 import gradio as gr
 import json
 import html


### PR DESCRIPTION
## Summary
- fix missing `shared` import by referencing project root instead of `modules` package

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507091e28c832b92c0a6923410210e