### PR TITLE
Fix LoRA template path lookup

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -9,6 +9,7 @@ _MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 def html(name: str) -> str:
     """Return contents of an HTML template bundled with the repo."""
     paths = [
+        os.path.join(_MODULE_DIR, "modules", "NewLoraSystem", "html", name),
         os.path.join(_MODULE_DIR, "NewLoraSystem", "html", name),
         os.path.join(_MODULE_DIR, "html", name),
     ]


### PR DESCRIPTION
## Summary
- expand the html helper to search modules/NewLoraSystem templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507e4de7d8832ba98926d52fd85701