### PR TITLE
Fix LoRA card HTML escaping

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -119,7 +119,7 @@ def generate_cards():
         if activation_text:
             prompt_text += f" {activation_text}"
         prompt = f"\"{prompt_text}\""
-        onclick = f"cardClicked('advanced', {prompt}, '' , false);"
+        onclick = html.escape(f"cardClicked('advanced', {prompt}, '' , false);")
         args = {
             'style': '',
             'card_clicked': onclick,


### PR DESCRIPTION
## Summary
- escape LoRA card onClick HTML so LoRA names with angle brackets don't break the UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685081e43d20832b975c1a81ad2da9cb