### PR TITLE
Fix LoRA folder path

### DIFF
--- a/modules/NewLoraSystem/sd_forge_lora/preload.py
+++ b/modules/NewLoraSystem/sd_forge_lora/preload.py
@@ -4,5 +4,11 @@ from modules.paths_internal import normalized_filepath
 
 
 def preload(parser):
-    parser.add_argument("--lora-dir", type=normalized_filepath, help="Path to directory with Lora networks.", default=os.path.join(paths.models_path, 'Lora'))
+    # Use the same default LoRA directory as Fooocus to keep compatibility
+    parser.add_argument(
+        "--lora-dir",
+        type=normalized_filepath,
+        help="Path to directory with Lora networks.",
+        default=os.path.join(paths.models_path, 'loras')
+    )
     parser.add_argument("--lyco-dir-backcompat", type=normalized_filepath, help="Path to directory with LyCORIS networks (for backawards compatibility; can also use --lyco-dir).", default=os.path.join(paths.models_path, 'LyCORIS'))


### PR DESCRIPTION
## Summary
- ensure the new LoRA system defaults to `models/loras`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850870475e8832bb611a4bffd7e647d