### PR TITLE
Add debug prints for LoRA UI

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -103,8 +103,10 @@ def generate_cards():
     copy_tpl = shared.html('extra-networks-copy-path-button.html')
     meta_tpl = shared.html('extra-networks-metadata-button.html')
     edit_tpl = shared.html('extra-networks-edit-item-button.html')
+    files = list_loras()
+    print('[LoRA UI] Detected files:', files)
     cards = []
-    for filepath in list_loras():
+    for filepath in files:
         name = os.path.splitext(os.path.basename(filepath))[0]
         preview = find_preview(filepath)
         if preview:
@@ -135,7 +137,9 @@ def generate_cards():
             'search_terms': '',
         }
         cards.append(card_tpl.format(**args))
-    return '\n'.join(cards)
+    html_out = '\n'.join(cards)
+    print('[LoRA UI] HTML output:', html_out[:200])
+    return html_out
 
 
 def load_editor(name):

--- a/webui.py
+++ b/webui.py
@@ -709,10 +709,12 @@ with shared.gradio_root:
                 lora_ctrls = []
                 with gr.Group():
                     from modules import simple_lora_ui
+                    print('[LoRA UI] Inserting cards into UI')
                     lora_html = gr.HTML(simple_lora_ui.generate_cards(), elem_id='lora_cards')
                     name_in, button_edit = simple_lora_ui.setup_ui('advanced', gallery, prompt)
 
                     def refresh_loras():
+                        print('[LoRA UI] Refreshing cards')
                         return gr.update(value=simple_lora_ui.generate_cards())
 
                 with gr.Row():


### PR DESCRIPTION
## Summary
- print detected LoRA files and resulting HTML from `generate_cards`
- log when inserting cards and refreshing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685093d87ac0832b85212c504c7a8b2f