### PR TITLE
Unify LoRA metadata helpers

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -1,0 +1,11 @@
+# Repository Structure
+
+- `modules/`: Core application modules and utilities.
+  - `NewLoraSystem/`: Implementation of the new LoRA system.
+  - `lora_utils.py`: Helper functions for locating LoRA files and handling metadata.
+- `models/`: Default model locations such as `loras`, `checkpoints`, etc.
+- `ldm_patched/`: Patched Stable Diffusion components.
+- `extras/`: Additional features including BLIP, expansion, and preprocessing tools.
+- `javascript/` and `css/`: Front‑end scripts and styles.
+- `tests/`: Unit tests for utility modules.
+- Other project files (`webui.py`, `launch.py`, etc.) start the application or configure runtime.

--- a/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
+++ b/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
@@ -1,11 +1,12 @@
 import datetime
 import html
 import random
+import os
 
 import gradio as gr
 import re
 
-from modules import ui_extra_networks_user_metadata
+from modules import ui_extra_networks_user_metadata, lora_utils
 
 
 def is_non_comma_tagset(tags):
@@ -57,6 +58,20 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
         self.edit_notes = None
         self.button_add_tags = None
         self.tags_text = None
+
+    def get_user_metadata(self, name):
+        path = lora_utils.get_lora_path(name)
+        if not path:
+            return {}
+        return lora_utils.read_user_metadata(path)
+
+    def write_user_metadata(self, name, metadata):
+        path = lora_utils.get_lora_path(name)
+        if not path:
+            return
+        lora_utils.write_user_metadata(path, metadata)
+        metadata_path = os.path.splitext(path)[0] + '.json'
+        self.page.lister.update_file_entry(metadata_path)
 
     def save_lora_user_metadata(self, name, desc, sd_version, activation_text, preferred_weight, negative_text, notes):
         user_metadata = self.get_user_metadata(name)

--- a/modules/lora_utils.py
+++ b/modules/lora_utils.py
@@ -1,0 +1,14 @@
+import os
+import json
+from typing import Dict, List, Optional
+
+from modules import lora_manager
+
+get_lora_path = lora_manager.get_lora_path
+read_metadata = lora_manager.read_metadata
+read_user_metadata = lora_manager.read_user_metadata
+write_user_metadata = lora_manager.write_user_metadata
+list_loras = lora_manager.list_loras
+find_preview = lora_manager.find_preview
+save_preview_image = lora_manager.save_preview_image
+build_tags = lora_manager.build_tags

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -2,7 +2,7 @@ import os
 from io import BytesIO
 from typing import List
 from PIL import Image
-from modules import lora_manager
+from modules import lora_utils
 import shared
 import gradio as gr
 import json
@@ -13,25 +13,25 @@ except Exception:
     st = None
 
 
-get_lora_path = lora_manager.get_lora_path
+get_lora_path = lora_utils.get_lora_path
 
 
-read_metadata = lora_manager.read_metadata
+read_metadata = lora_utils.read_metadata
 
 
-read_user_metadata = lora_manager.read_user_metadata
+read_user_metadata = lora_utils.read_user_metadata
 
 
-write_user_metadata = lora_manager.write_user_metadata
+write_user_metadata = lora_utils.write_user_metadata
 
 
-list_loras = lora_manager.list_loras
+list_loras = lora_utils.list_loras
 
 
-find_preview = lora_manager.find_preview
+find_preview = lora_utils.find_preview
 
 
-build_tags = lora_manager.build_tags
+build_tags = lora_utils.build_tags
 
 
 def generate_cards():


### PR DESCRIPTION
## Summary
- add `lora_utils` wrapper module
- update simple LoRA UI to use `lora_utils`
- update `LoraUserMetadataEditor` to load/save via `lora_utils`
- document repository layout in `manifest.md`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c681d68832b8692a783e582dd5f