### PR TITLE
Fix card prompt insertion

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -967,7 +967,8 @@ footer {
 }
 
 .extra-network-pane .card:hover .card-buttons{
-    display: block;
+    display: flex;
+    gap: 4px;
 }
 
 .extra-network-pane .card-button{
@@ -1654,7 +1655,8 @@ body.resizing .resize-handle {
 }
 
 .extra-network-tree .tree-list-content:hover .card-buttons {
-    display: block;
+    display: flex;
+    gap: 4px;
 }
 
 .prompt textarea[disabled] {

--- a/modules/NewLoraSystem/html/extra-networks-card.html
+++ b/modules/NewLoraSystem/html/extra-networks-card.html
@@ -1,8 +1,10 @@
-<div class="card" style="{style}" onclick="{card_clicked}" data-name="{name}" data-file="{filename}" {sort_keys}>
-	{background_image}
+<div class="card" style="{style}" onclick="{card_clicked}" data-name="{name}" data-file="{filename}" {sort_keys}
+     onmouseover="this.querySelector('.card-buttons').style.display='block'"
+     onmouseout="this.querySelector('.card-buttons').style.display='none'">
+        {background_image}
         <div class="card-buttons">{copy_path_button}{metadata_button}{edit_button}</div>
-	<div class="actions">
-		<div class="additional">{search_terms}</div>
+        <div class="actions">
+                <div class="additional">{search_terms}</div>
 		<span class="name">{name}</span>
 		<span class="description">{description}</span>
 	</div>

--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -264,12 +264,19 @@ function updatePromptArea(text, textArea, isNeg) {
 }
 
 function cardClicked(tabname, textToAdd, textToAddNegative, allowNegativePrompt) {
-    if (textToAddNegative.length > 0) {
-        updatePromptArea(textToAdd, gradioApp().querySelector("#" + tabname + "_prompt > label > textarea"));
-        updatePromptArea(textToAddNegative, gradioApp().querySelector("#" + tabname + "_neg_prompt > label > textarea"), true);
+    const promptArea = document.querySelector('#positive_prompt textarea, textarea[placeholder="Prompt"]');
+    const negPromptArea = document.querySelector('#negative_prompt textarea, textarea[placeholder="Negative prompt"]');
+
+    if (!promptArea) {
+        console.warn('Prompt area not found');
+        return;
+    }
+
+    if (textToAddNegative.length > 0 && negPromptArea) {
+        updatePromptArea(textToAdd, promptArea);
+        updatePromptArea(textToAddNegative, negPromptArea, true);
     } else {
-        var textarea = allowNegativePrompt ? activePromptTextarea[tabname] : gradioApp().querySelector("#" + tabname + "_prompt > label > textarea");
-        updatePromptArea(textToAdd, textarea);
+        updatePromptArea(textToAdd, promptArea);
     }
 }
 


### PR DESCRIPTION
## Summary
- show card controls on hover with inline events
- insert LoRA text into the prompt field in Fooocus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a9fadaf4832babe2a5a6278bbf44