### PR TITLE
Fix extraNetworks setup for Fooocus

### DIFF
--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -207,8 +207,11 @@ var extraNetworksApplySort = {};
 var activePromptTextarea = {};
 
 function setupExtraNetworks() {
-    setupExtraNetworksForTab('txt2img');
-    setupExtraNetworksForTab('img2img');
+    ['txt2img', 'img2img'].forEach(function(tab){
+        if (gradioApp().querySelector('#' + tab + '_extra_tabs')) {
+            setupExtraNetworksForTab(tab);
+        }
+    });
 }
 
 var re_extranet = /<([^:^>]+:[^:]+):[\d.]+>(.*)/;


### PR DESCRIPTION
## Summary
- avoid warnings when extra network tabs like `txt2img` or `img2img` are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850af5bec4c832baf0e8a1c2b8f076f