### PR TITLE
Enable LoRA card hover via extra-network wrapper

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -80,8 +80,9 @@ def generate_cards():
             'search_terms': '',
         }
         cards.append(card_tpl.format(**args))
-    html_out = '\n'.join(cards)
-    print('[LoRA UI] HTML output:', html_out[:200])
+    cards_html = '\n'.join(cards)
+    html_out = f"<div class='extra-network-pane'><div class='extra-network-cards'>{cards_html}</div></div>"
+    print('[LoRA UI] HTML output:', cards_html[:200])
     return html_out
 
 


### PR DESCRIPTION
## Summary
- wrap LoRA card HTML with `extra-network-pane` and `extra-network-cards` container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ba8b2df4832bb5717371b65d3c6d