### PR TITLE
Fix metadata panel and card preview sizing

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1092,8 +1092,8 @@ footer {
 }
 
 .extra-network-pane .card .preview{
-    width: 160px;
-    height: 160px;
+    width: 100%;
+    height: 100%;
     border-radius: 12px;
     object-fit: cover;
 }

--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -601,6 +601,30 @@ function addTagsToPrompt(tags, tabname){
     updatePromptArea(tags, textarea);
 }
 
+function createVisualizationTable(tags, tagFrequencies){
+    const table = document.createElement("table");
+    table.className = "metadata-visualization";
+
+    Object.keys(tags).forEach(tag => {
+        const row = document.createElement("tr");
+        const labelCell = document.createElement("td");
+        labelCell.textContent = tag;
+
+        const valueCell = document.createElement("td");
+        if(tagFrequencies && typeof tagFrequencies === 'object'){
+            valueCell.textContent = tagFrequencies[tag] || 0;
+        }else{
+            valueCell.textContent = tags[tag];
+        }
+
+        row.appendChild(labelCell);
+        row.appendChild(valueCell);
+        table.appendChild(row);
+    });
+
+    return table;
+}
+
 function extraNetworksShowMetadata(text, tabname) {
     try {
         let parsed = JSON.parse(text);


### PR DESCRIPTION
## Summary
- make preview images fill their cards
- provide missing `createVisualizationTable` implementation used when viewing metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c047c128832bbb7328177c8f7318