### PR TITLE
Fix float conversion for disabled loras

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -64,7 +64,13 @@ class AsyncTask:
         self.base_model_name = args.pop()
         self.refiner_model_name = args.pop()
         self.refiner_switch = args.pop()
-        self.loras = get_enabled_loras([(bool(args.pop()), str(args.pop()), float(args.pop())) for _ in
+        def _safe_float(val: any, default: float = 0.0) -> float:
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                return default
+
+        self.loras = get_enabled_loras([(bool(args.pop()), str(args.pop()), _safe_float(args.pop())) for _ in
                                         range(default_max_lora_number)])
         self.input_image_checkbox = args.pop()
         self.current_tab = args.pop()


### PR DESCRIPTION
## Summary
- guard against invalid LoRA weight strings so disabled loras do not crash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c501efec832ba95ca8ec2a0f84e0