### PR TITLE
Fix invalid metadata scheme error

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -127,8 +127,15 @@ class AsyncTask:
         self.inpaint_erode_or_dilate = args.pop()
         self.save_final_enhanced_image_only = args.pop() if not args_manager.args.disable_image_log else False
         self.save_metadata_to_images = args.pop() if not args_manager.args.disable_metadata else False
-        self.metadata_scheme = MetadataScheme(
-            args.pop()) if not args_manager.args.disable_metadata else MetadataScheme.FOOOCUS
+        if not args_manager.args.disable_metadata:
+            scheme_value = args.pop()
+            try:
+                self.metadata_scheme = MetadataScheme(scheme_value)
+            except ValueError:
+                print(f'[AsyncTask] Invalid metadata scheme: {scheme_value}, falling back to FOOOCUS')
+                self.metadata_scheme = MetadataScheme.FOOOCUS
+        else:
+            self.metadata_scheme = MetadataScheme.FOOOCUS
 
         self.cn_tasks = {x: [] for x in ip_list}
         for _ in range(modules.config.default_controlnet_image_count):


### PR DESCRIPTION
## Summary
- avoid crash when metadata scheme value is invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c77e91b8832bbe4417bf6e838fe9