### PR TITLE
Fix LoRA editor popup

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1031,7 +1031,7 @@ footer {
     overflow: hidden;
     cursor: pointer;
 
-    background-image: url('./file=html/card-no-preview.png')
+    background-image: url('/file=modules/NewLoraSystem/html/card-no-preview.png')
 }
 
 .extra-network-pane .card:hover{

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -178,7 +178,7 @@ def save_preview(name, gallery: List, index: int):
 
 
 def create_editor_ui(tabname: str, gallery, prompt):
-    with gr.Box(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata", elem_classes="edit-user-metadata"):
+    with gr.Box(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata", elem_classes="edit-user-metadata") as box:
         name_in = gr.Textbox(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata_name")
         button_edit = gr.Button("Edit user metadata", visible=False, elem_id=f"{tabname}_lora_edit_user_metadata_button")
         title = gr.HTML()
@@ -209,7 +209,11 @@ def create_editor_ui(tabname: str, gallery, prompt):
 
         add_tags.click(fn=add_tags_fn, inputs=[tags, prompt], outputs=prompt, show_progress=False)
 
-        button_edit.click(fn=load_editor, inputs=[name_in], outputs=[title, desc, activation, weight, notes, sd_version, tags, preview_html, filedata_html])
+        button_edit.click(
+            fn=load_editor,
+            inputs=[name_in],
+            outputs=[title, desc, activation, weight, notes, sd_version, tags, preview_html, filedata_html],
+        ).then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[box])
 
         save.click(fn=save_metadata, inputs=[name_in, desc, activation, weight, notes, sd_version], outputs=status).then(fn=None, _js='refreshLoraCards')
 


### PR DESCRIPTION
## Summary
- fix missing preview image by using absolute path in CSS
- show the LoRA editor popup by revealing its hidden box after loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cbf774f0832bbbfda359fc41d9e1