### PR TITLE
Fix CN task initialization

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -143,7 +143,7 @@ class AsyncTask:
             cn_stop = args.pop()
             cn_weight = args.pop()
             cn_type = args.pop()
-            if cn_img is not None:
+            if cn_img is not None and cn_type in self.cn_tasks:
                 self.cn_tasks[cn_type].append([cn_img, cn_stop, cn_weight])
 
         self.debugging_dino = args.pop()


### PR DESCRIPTION
## Summary
- check that `cn_type` exists in `cn_tasks` dictionary before appending

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d640fce4832bbfea213d15f91598