### PR TITLE
Add debug info for AsyncTask args

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -25,7 +25,9 @@ class AsyncTask:
         self.performance_loras = []
 
         if len(args) == 0:
-            return
+            raise RuntimeError(
+                "Received empty args list in AsyncTask, expected at least 1 element."
+            )
 
         args.reverse()
         self.generate_image_grid = args.pop()
@@ -157,6 +159,9 @@ class AsyncTask:
         self.enhance_uov_prompt_type = args.pop()
         self.enhance_ctrls = []
         for _ in range(modules.config.default_enhance_tabs):
+            if len(args) < 16:
+                print("[AsyncTask] Warning: Received incomplete enhance arguments.")
+                break
             enhance_enabled = args.pop()
             enhance_mask_dino_prompt_text = args.pop()
             enhance_prompt = args.pop()

--- a/webui.py
+++ b/webui.py
@@ -31,6 +31,9 @@ def get_task(*args):
     args = list(args)
     args.pop(0)
 
+    # Debug the arguments passed to AsyncTask
+    print(f"[DEBUG] args before AsyncTask: {args}")
+
     return worker.AsyncTask(args=args)
 
 def generate_clicked(task: worker.AsyncTask):


### PR DESCRIPTION
## Summary
- add debug print before constructing AsyncTask
- validate non-empty arg list in `AsyncTask` constructor
- guard against incomplete enhance arguments to prevent IndexError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d9a81f44832bac714d3f4db43b3d