### PR TITLE
Fix type error when path is bool

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -445,12 +445,22 @@ def get_file_from_folder_list(name, folders):
     if not isinstance(folders, list):
         folders = [folders]
 
+    valid_folders = []
     for folder in folders:
+        if isinstance(folder, (str, os.PathLike)):
+            valid_folders.append(folder)
+        else:
+            print(f'Warning: ignoring invalid folder path {folder!r}')
+
+    if not valid_folders:
+        raise TypeError('No valid folder paths provided to get_file_from_folder_list')
+
+    for folder in valid_folders:
         filename = os.path.abspath(os.path.realpath(os.path.join(folder, name)))
         if os.path.isfile(filename):
             return filename
 
-    return os.path.abspath(os.path.realpath(os.path.join(folders[0], name)))
+    return os.path.abspath(os.path.realpath(os.path.join(valid_folders[0], name)))
 
 
 def get_enabled_loras(loras: list, remove_none=True) -> list:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,3 +175,19 @@ class TestWildcardCache(unittest.TestCase):
 
         modules.config.path_wildcards = original_path
         modules.config.wildcard_filenames = original_files
+
+
+class TestGetFileFromFolderList(unittest.TestCase):
+    def test_invalid_folder_path_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = 'file.txt'
+            path = os.path.join(tmpdir, test_file)
+            with open(path, 'w') as f:
+                f.write('data')
+
+            filename = util.get_file_from_folder_list(test_file, [True, tmpdir])
+            self.assertEqual(filename, os.path.abspath(path))
+
+    def test_all_invalid_raises(self):
+        with self.assertRaises(TypeError):
+            util.get_file_from_folder_list('file.txt', True)


### PR DESCRIPTION
## Summary
- guard `get_file_from_folder_list` against non-path inputs
- test that invalid paths are skipped and errors raised when no valid path is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e3f9530c832b8349a703bac28e2f