### PR TITLE
Fix TypeError in util file lookup

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -442,6 +442,13 @@ def get_filname_by_stem(lora_name, filenames: List[str]) -> str | None:
 
 
 def get_file_from_folder_list(name, folders):
+    if not isinstance(name, (str, os.PathLike)):
+        raise TypeError(
+            f"Invalid file name type {type(name).__name__}; expected str or os.PathLike"
+        )
+
+    name = os.fspath(name)
+
     if not isinstance(folders, list):
         folders = [folders]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,3 +191,8 @@ class TestGetFileFromFolderList(unittest.TestCase):
     def test_all_invalid_raises(self):
         with self.assertRaises(TypeError):
             util.get_file_from_folder_list('file.txt', True)
+
+    def test_invalid_name_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(TypeError):
+                util.get_file_from_folder_list(True, [tmpdir])


### PR DESCRIPTION
## Summary
- guard against invalid names in `get_file_from_folder_list`
- test the new validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e6b87814832bbdb6488914266dc4