### PR TITLE
Ensure int image dimensions

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -718,6 +718,7 @@ def worker():
             width = async_task.overwrite_width
         if async_task.overwrite_height > 0:
             height = async_task.overwrite_height
+        width, height = int(width), int(height)
         return steps, switch, width, height
 
     def process_prompt(async_task, prompt, negative_prompt, base_model_additional_loras, image_number, disable_seed_increment, use_expansion, use_style,

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -374,6 +374,9 @@ def get_candidate_vae(steps, switch, denoise=1.0, refiner_swap_method='joint'):
 @torch.no_grad()
 @torch.inference_mode()
 def process_diffusion(positive_cond, negative_cond, steps, switch, width, height, image_seed, callback, sampler_name, scheduler_name, latent=None, denoise=1.0, tiled=False, cfg_scale=7.0, refiner_swap_method='joint', disable_preview=False):
+    width = int(width)
+    height = int(height)
+    assert width >= 8 and height >= 8, "Width/Height too small for convolution layers"
     target_unet, target_vae, target_refiner_unet, target_refiner_vae, target_clip \
         = final_unet, final_vae, final_refiner_unet, final_refiner_vae, final_clip
 
@@ -399,7 +402,7 @@ def process_diffusion(positive_cond, negative_cond, steps, switch, width, height
     print(f'[Sampler] refiner_swap_method = {refiner_swap_method}')
 
     if latent is None:
-        initial_latent = core.generate_empty_latent(width=width, height=height, batch_size=1)
+        initial_latent = core.generate_empty_latent(width=int(width), height=int(height), batch_size=1)
     else:
         initial_latent = latent
 


### PR DESCRIPTION
## Summary
- cast width and height to `int` to prevent float sizes in sampler
- ensure overrides return integer dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f7c2c808832b88f7243117c10879