### PR TITLE
Fix aspect ratio parsing for default pipeline

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -253,9 +253,19 @@ def worker():
     from modules.sdxl_styles import apply_style, get_random_style, fooocus_expansion, apply_arrays, random_style_name
     from modules.private_logger import log
     from extras.expansion import safe_str
-    from modules.util import (remove_empty_str, HWC3, resize_image, get_image_shape_ceil, set_image_shape_ceil,
-                              get_shape_ceil, resample_image, erode_or_dilate, parse_lora_references_from_prompt,
-                              apply_wildcards)
+    from modules.util import (
+        remove_empty_str,
+        HWC3,
+        resize_image,
+        get_image_shape_ceil,
+        set_image_shape_ceil,
+        get_shape_ceil,
+        resample_image,
+        erode_or_dilate,
+        parse_lora_references_from_prompt,
+        apply_wildcards,
+        parse_resolution_label,
+    )
     from modules.upscaler import perform_upscale
     from modules.flags import Performance
     from modules.meta_parser import get_metadata_parser
@@ -1230,8 +1240,7 @@ def worker():
         denoising_strength = 1.0
         tiled = False
 
-        width, height = async_task.aspect_ratios_selection.replace('×', ' ').split(' ')[:2]
-        width, height = int(width), int(height)
+        width, height = modules.util.parse_resolution_label(async_task.aspect_ratios_selection)
 
         skip_prompt_processing = False
 

--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -12,7 +12,14 @@ import modules.sdxl_styles
 from modules.flags import MetadataScheme, Performance, Steps
 from modules.flags import SAMPLERS, CIVITAI_NO_KARRAS
 from modules.hash_cache import sha256_from_cache
-from modules.util import quote, unquote, extract_styles_from_prompt, is_json, get_file_from_folder_list
+from modules.util import (
+    quote,
+    unquote,
+    extract_styles_from_prompt,
+    is_json,
+    get_file_from_folder_list,
+    parse_resolution_label,
+)
 
 re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'
 re_param = re.compile(re_param_code)
@@ -261,11 +268,9 @@ def parse_meta_from_preset(preset_content):
         elif settings_key == "default_aspect_ratio":
             if settings_key in items and items[settings_key] is not None:
                 default_aspect_ratio = items[settings_key]
-                width, height = default_aspect_ratio.split('*')
             else:
                 default_aspect_ratio = getattr(modules.config, settings_key)
-                width, height = default_aspect_ratio.split('×')
-                height = height[:height.index(" ")]
+            width, height = modules.util.parse_resolution_label(default_aspect_ratio)
             preset_prepared[meta_key] = (width, height)
         else:
             preset_prepared[meta_key] = items[settings_key] if settings_key in items and items[settings_key] is not None else getattr(modules.config, settings_key)

--- a/modules/util.py
+++ b/modules/util.py
@@ -554,6 +554,22 @@ def cleanup_prompt(prompt):
     return cleaned_prompt[:-2]
 
 
+def parse_resolution_label(label: str) -> tuple[int, int]:
+    """Extract ``width`` and ``height`` integers from aspect ratio label strings.
+
+    Examples of supported formats include ``'832×1216 <span>'``, ``'640*1536'``
+    and ``'512x512'``.  If extraction fails the function returns ``(0, 0)``.
+    """
+    if not isinstance(label, str):
+        return 0, 0
+
+    cleaned = label.replace('×', ' ').replace('*', ' ').replace('x', ' ')
+    digits = re.findall(r"\d+", cleaned)
+    if len(digits) >= 2:
+        return int(digits[0]), int(digits[1])
+    return 0, 0
+
+
 def apply_wildcards(wildcard_text, rng, i, read_wildcards_in_order) -> str:
     for _ in range(modules.config.wildcards_max_bfs_depth):
         placeholders = re.findall(r'__([\w-]+)__', wildcard_text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,5 +194,18 @@ class TestGetFileFromFolderList(unittest.TestCase):
 
     def test_invalid_name_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with self.assertRaises(TypeError):
-                util.get_file_from_folder_list(True, [tmpdir])
+                with self.assertRaises(TypeError):
+                    util.get_file_from_folder_list(True, [tmpdir])
+
+
+class TestParseResolutionLabel(unittest.TestCase):
+    def test_parses_resolution_label(self):
+        cases = [
+            ("832×1216 <span style='color: grey;'>∣ 13:19</span>", (832, 1216)),
+            ("640*1536", (640, 1536)),
+            ("512x512", (512, 512)),
+            ("invalid", (0, 0)),
+        ]
+
+        for value, expected in cases:
+            self.assertEqual(util.parse_resolution_label(value), expected)


### PR DESCRIPTION
## Summary
- handle aspect ratio strings with HTML by adding `parse_resolution_label`
- use the helper in AsyncTask and metadata parser
- test parsing logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ffcf29ec832bbb5857d72f78971d