### PR TITLE
Fix FreeU patch default handling

### DIFF
--- a/ldm_patched/contrib/external_freelunch.py
+++ b/ldm_patched/contrib/external_freelunch.py
@@ -45,7 +45,7 @@ class FreeU:
 
         def output_block_patch(h, hsp, transformer_options):
             scale = scale_dict.get(h.shape[1], None)
-            if scale is not None:
+            if scale is not None and scale[0] is not None and scale[1] is not None:
                 h[:,:h.shape[1] // 2] = h[:,:h.shape[1] // 2] * scale[0]
                 if hsp.device not in on_cpu_devices:
                     try:
@@ -84,7 +84,7 @@ class FreeU_V2:
 
         def output_block_patch(h, hsp, transformer_options):
             scale = scale_dict.get(h.shape[1], None)
-            if scale is not None:
+            if scale is not None and scale[0] is not None and scale[1] is not None:
                 hidden_mean = h.mean(1).unsqueeze(1)
                 B = hidden_mean.shape[0]
                 hidden_max, _ = torch.max(hidden_mean.view(B, -1), dim=-1, keepdim=True)


### PR DESCRIPTION
## Summary
- avoid `TypeError` when FreeU patch scales are unset
- ensure both scale values are present before applying FreeU filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685101b172b4832bb79114cd1cdf54f0