### PR TITLE
Fix metadata parser with invalid VAE arg

### DIFF
--- a/modules/meta_parser.py
+++ b/modules/meta_parser.py
@@ -335,7 +335,12 @@ class MetadataParser(ABC):
                 else:
                     lora_hash = sha256_from_cache(lora_path)
                 self.loras.append((Path(lora_name).stem, lora_weight, lora_hash))
-        self.vae_name = Path(vae_name).stem
+        # handle invalid values that are not path-like
+        if isinstance(vae_name, (str, os.PathLike)):
+            self.vae_name = Path(vae_name).stem
+        else:
+            print(f"[Warning] Invalid vae_name type: {type(vae_name).__name__} -> {vae_name}")
+            self.vae_name = 'invalid'
 
 
 class A1111MetadataParser(MetadataParser):


### PR DESCRIPTION
## Summary
- guard against boolean values when parsing VAE names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685113dc91b8832bb816a1ffb36d6b17