### PR TITLE
Fix LoRA argument alignment

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -31,6 +31,15 @@ def get_task(*args):
     args = list(args)
     args.pop(0)
 
+    # Insert default LoRA placeholders if the UI didn't provide any.
+    lora_placeholders = []
+    for enabled, name, weight in modules.config.default_loras:
+        lora_placeholders.extend([enabled, name, weight])
+
+    lora_insert_index = 16  # after base_model, refiner_model, refiner_switch
+    if len(args) < lora_insert_index + len(lora_placeholders):
+        args[lora_insert_index:lora_insert_index] = lora_placeholders
+
     # Debug the arguments passed to AsyncTask
     print(f"[DEBUG] args before AsyncTask: {args}")
 


### PR DESCRIPTION
## Summary
- insert default LoRA arguments when the UI doesn't provide any

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685117c2c1cc832bbe8c9f1f0fb2789e