### PR TITLE
Integrate SafeAsyncTask for LoRA loading

### DIFF
--- a/modules/safe_async_task.py
+++ b/modules/safe_async_task.py
@@ -1,0 +1,23 @@
+import os
+from modules.async_worker import AsyncTask
+from modules.lora_utils import get_lora_path
+
+
+class SafeAsyncTask(AsyncTask):
+    """AsyncTask wrapper that validates LoRA paths before processing."""
+
+    def __init__(self, args):
+        super().__init__(args)
+
+        validated = []
+        for name, weight in self.loras:
+            if name in {"", "None"}:
+                validated.append((name, weight))
+                continue
+
+            path = get_lora_path(name)
+            if path and os.path.isfile(path):
+                validated.append((path, weight))
+            else:
+                print(f"[SafeAsyncTask] Warning: LoRA file not found: {name}")
+        self.loras = validated

--- a/webui.py
+++ b/webui.py
@@ -8,6 +8,7 @@ import modules.config
 import fooocus_version
 import modules.html
 import modules.async_worker as worker
+from modules.safe_async_task import SafeAsyncTask
 import modules.constants as constants
 import modules.flags as flags
 import modules.gradio_hijack as grh
@@ -43,9 +44,9 @@ def get_task(*args):
     # Debug the arguments passed to AsyncTask
     print(f"[DEBUG] args before AsyncTask: {args}")
 
-    return worker.AsyncTask(args=args)
+    return SafeAsyncTask(args=args)
 
-def generate_clicked(task: worker.AsyncTask):
+def generate_clicked(task: SafeAsyncTask):
     import ldm_patched.modules.model_management as model_management
 
     with model_management.interrupt_processing_mutex:
@@ -1124,7 +1125,7 @@ with shared.gradio_root:
             .then(fn=update_history_link, outputs=history_link) \
             .then(fn=lambda: None, _js='playNotification').then(fn=lambda: None, _js='refresh_grid_delayed')
 
-        reset_button.click(lambda: [worker.AsyncTask(args=[]), False, gr.update(visible=True, interactive=True)] +
+        reset_button.click(lambda: [SafeAsyncTask(args=[]), False, gr.update(visible=True, interactive=True)] +
                                    [gr.update(visible=False)] * 6 +
                                    [gr.update(visible=True, value=[])],
                            outputs=[currentTask, state_is_generating, generate_button,


### PR DESCRIPTION
## Summary
- add `SafeAsyncTask` wrapper that validates LoRA files
- use `SafeAsyncTask` in `webui.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511ef15e84832baa230651120e06b0