### PR TITLE
Fix module path for LoRA imports

### DIFF
--- a/entry_with_update.py
+++ b/entry_with_update.py
@@ -4,6 +4,7 @@ import sys
 
 root = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(root)
+sys.path.append(os.path.join(root, 'modules', 'NewLoraSystem', 'sd_forge_lora'))
 os.chdir(root)
 
 

--- a/launch.py
+++ b/launch.py
@@ -6,6 +6,7 @@ print('[System ARGV] ' + str(sys.argv))
 
 root = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(root)
+sys.path.append(os.path.join(root, 'modules', 'NewLoraSystem', 'sd_forge_lora'))
 os.chdir(root)
 
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"


### PR DESCRIPTION
## Summary
- expose `sd_forge_lora` in `sys.path` so `network` module can be imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a9887a68832bb3e6b682384a7c18