### PR TITLE
Fix LoRA UI integration with legacy pipeline

### DIFF
--- a/modules/NewLoraSystem/javascrypt/extraNetworks.js
+++ b/modules/NewLoraSystem/javascrypt/extraNetworks.js
@@ -281,6 +281,18 @@ function cardClicked(tabname, textToAdd, textToAddNegative, allowNegativePrompt)
     } else {
         updatePromptArea(textToAdd, promptArea);
     }
+
+    const loraBox = gradioApp().querySelector('#lora_selection_json textarea');
+    if (loraBox) {
+        let data = [];
+        try { data = JSON.parse(loraBox.value || '[]'); } catch (e) {}
+        const m = textToAdd.match(/<lora:([^:]+):([+-]?(?:\d+(?:\.\d*)?|\.\d+))>/);
+        if (m) {
+            data.push([m[1] + '.safetensors', parseFloat(m[2])]);
+            loraBox.value = JSON.stringify(data);
+            loraBox.dispatchEvent(new Event('input', {bubbles: true}));
+        }
+    }
 }
 
 function saveCardPreview(event, tabname, filename) {

--- a/webui.py
+++ b/webui.py
@@ -32,16 +32,34 @@ def get_task(*args):
     args = list(args)
     args.pop(0)
 
-    # Insert default LoRA placeholders if the UI didn't provide any.
+    lora_insert_index = 16  # after base_model, refiner_model, refiner_switch
+    lora_json = "[]"
+    if len(args) > lora_insert_index:
+        lora_json = args.pop(lora_insert_index)
+
+    selected_loras = []
+    try:
+        selected_loras = json.loads(lora_json)
+    except Exception as e:
+        print(f"[DEBUG] failed to parse lora selection: {e}")
+
     lora_placeholders = []
+    max_slots = modules.config.default_max_lora_number
+    combined = []
+    for name, weight in selected_loras:
+        combined.append((True, name, weight))
+        if len(combined) >= max_slots:
+            break
     for enabled, name, weight in modules.config.default_loras:
+        if len(combined) >= max_slots:
+            break
+        combined.append((enabled, name, weight))
+
+    for enabled, name, weight in combined:
         lora_placeholders.extend([enabled, name, weight])
 
-    lora_insert_index = 16  # after base_model, refiner_model, refiner_switch
-    if len(args) < lora_insert_index + len(lora_placeholders):
-        args[lora_insert_index:lora_insert_index] = lora_placeholders
+    args[lora_insert_index:lora_insert_index] = lora_placeholders
 
-    # Debug the arguments passed to AsyncTask
     print(f"[DEBUG] args before AsyncTask: {args}")
 
     return SafeAsyncTask(args=args)
@@ -727,6 +745,8 @@ with shared.gradio_root:
                     print('[LoRA UI] Inserting cards into UI')
                     lora_html = gr.HTML(simple_lora_ui.generate_cards(), elem_id='lora_cards')
                     name_in, button_edit = simple_lora_ui.setup_ui('advanced', gallery, prompt)
+                    lora_selection = gr.Textbox(visible=False, elem_id='lora_selection_json', value='[]')
+                    lora_ctrls.append(lora_selection)
 
                     def refresh_loras():
                         print('[LoRA UI] Refreshing cards')


### PR DESCRIPTION
## Summary
- allow NewLoraSystem selections to be sent back to the backend
- parse selected LoRAs and insert them into the args for `AsyncTask`
- track selections via hidden textbox and update it in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b0403d14832bb5aa7aa124d1827a