### PR TITLE
Fix torch.load weights_only issue

### DIFF
--- a/modules/NewLoraSystem/shared_networks.py
+++ b/modules/NewLoraSystem/shared_networks.py
@@ -57,7 +57,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
 
 @functools.lru_cache(maxsize=5)
 def load_lora_state_dict(filename):
-    return torch.load(filename, map_location="cpu")
+    return torch.load(filename, map_location="cpu", weights_only=False)
 
 
 def load_network(name, network_on_disk):


### PR DESCRIPTION
## Summary
- handle PyTorch 2.6 change when loading LoRA files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851eeff17f0832bb3d381892a013b4f