### PR TITLE
Fix LoRA load error with PyTorch 2.6

### DIFF
--- a/modules/NewLoraSystem/shared_networks.py
+++ b/modules/NewLoraSystem/shared_networks.py
@@ -57,7 +57,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
 
 @functools.lru_cache(maxsize=5)
 def load_lora_state_dict(filename):
-    return torch.load(filename, map_location="cpu", weights_only=False)
+    return torch.load(filename, map_location="cpu", weights_only=True)
 
 
 def load_network(name, network_on_disk):


### PR DESCRIPTION
## Summary
- ensure LoRA state dict uses `weights_only=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fa356298832b9a7e34e00bfc5740