### PR TITLE
Fix LoRA loading for .safetensors files

### DIFF
--- a/modules/NewLoraSystem/shared_networks.py
+++ b/modules/NewLoraSystem/shared_networks.py
@@ -58,7 +58,8 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
 
 @functools.lru_cache(maxsize=5)
 def load_lora_state_dict(filename):
-    if filename.endswith(".safetensors"):
+    ext = os.path.splitext(filename)[-1].lower()
+    if ext == ".safetensors":
         return load_file(filename, device="cpu")
     else:
         return torch.load(filename, map_location="cpu", weights_only=False)


### PR DESCRIPTION
## Summary
- handle `.safetensors` extension in `load_lora_state_dict`

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_685201cc85fc832b8e15516060f4f8e9