### PR TITLE
Silence extraneous LoRA warnings

### DIFF
--- a/ldm_patched/modules/lora.py
+++ b/ldm_patched/modules/lora.py
@@ -156,7 +156,8 @@ def load_lora(lora, to_load):
 
     for x in lora.keys():
         if x not in loaded_keys:
-            print("lora key not loaded", x)
+            # silenced to prevent excessive log spam
+            pass
     return patch_dict
 
 def model_lora_keys_clip(model, key_map={}):


### PR DESCRIPTION
## Summary
- suppress `lora key not loaded` log spam when applying LoRA patches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685226125d8c832b98b59e2133248267