### PR TITLE
Fix tag autocomplete path

### DIFF
--- a/modules/ui_gradio_extensions.py
+++ b/modules/ui_gradio_extensions.py
@@ -16,6 +16,9 @@ script_path = os.path.dirname(modules_path)
 
 
 def webpath(fn):
+    if not os.path.isabs(fn):
+        fn = os.path.join(script_path, fn)
+
     if fn.startswith(script_path):
         web_path = os.path.relpath(fn, script_path).replace('\\', '/')
     else:


### PR DESCRIPTION
## Summary
- fix `webpath` to build relative URLs correctly so tag autocomplete assets load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685227d73948832ba60b97b7f26dee24