### PR TITLE
Fix preview replacement index handling

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -155,13 +155,16 @@ def save_metadata(name, description, activation, weight, notes, sd_version):
     return ''
 
 
-def save_preview(name, gallery: List, index: int):
+def save_preview(name, gallery: List, index):
     path = get_lora_path(name)
     if not path:
         return ''
     if not gallery:
         return ''
-    index = int(index)
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        index = 0
     index = max(0, min(index, len(gallery) - 1))
     img_data = gallery[index]
     if isinstance(img_data, str):


### PR DESCRIPTION
## Summary
- handle missing gallery index when replacing LoRA previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524074dd84832baddd105495ac8539