### PR TITLE
Fix preview refresh in LoRA UI

### DIFF
--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -79,9 +79,13 @@ def generate_cards():
     )
     for filepath in files:
         name = os.path.splitext(os.path.basename(filepath))[0]
-        preview = find_preview(filepath)
-        if not preview or not os.path.exists(preview):
-            preview = default_preview
+        preview_path = os.path.join("models", "loras_previews", f"{name}.preview.png")
+        if os.path.exists(preview_path):
+            preview = preview_path
+        else:
+            preview = find_preview(filepath)
+            if not preview or not os.path.exists(preview):
+                preview = default_preview
         preview_html = f'<img src="file={preview}" class="preview">'
         metadata = read_metadata(filepath)
         metadata_json = html.escape(json.dumps(metadata))
@@ -134,9 +138,13 @@ def load_editor(name):
         "html",
         "card-no-preview.png",
     )
-    preview = find_preview(path)
-    if not preview or not os.path.exists(preview):
-        preview = default_preview
+    preview_path = os.path.join("models", "loras_previews", f"{name}.preview.png")
+    if os.path.exists(preview_path):
+        preview = preview_path
+    else:
+        preview = find_preview(path)
+        if not preview or not os.path.exists(preview):
+            preview = default_preview
     preview_html = f'<img src="file={preview}" class="preview">'
     return [name, desc, activation, weight, notes, sd_version, tags, preview_html, filedata]
 

--- a/webui.py
+++ b/webui.py
@@ -970,7 +970,7 @@ with shared.gradio_root:
                 dev_mode.change(dev_mode_checked, inputs=[dev_mode], outputs=[dev_tools],
                                 queue=False, show_progress=False)
 
-                def refresh_files_clicked():
+                def refresh_files_clicked_simple():
                     modules.config.update_files()
                     modules.sd_upscale.reload_upscalers()
                     results = [gr.update(choices=modules.config.model_filenames)]
@@ -978,9 +978,6 @@ with shared.gradio_root:
                     results += [gr.update(choices=[flags.default_vae] + modules.config.vae_filenames)]
                     if not args_manager.args.disable_preset_selection:
                         results += [gr.update(choices=modules.config.available_presets)]
-                    for i in range(modules.config.default_max_lora_number):
-                        results += [gr.update(interactive=True),
-                                    gr.update(choices=['None'] + modules.config.lora_filenames), gr.update()]
                     results += [gr.update(choices=modules.sd_upscale.DEFAULT_UPSCALERS)]
                     return results
 
@@ -988,7 +985,7 @@ with shared.gradio_root:
                 if not args_manager.args.disable_preset_selection:
                     refresh_files_output += [preset_selection]
                 refresh_files_output += [sd_upscaler]
-                refresh_files.click(refresh_files_clicked, [], refresh_files_output + lora_ctrls,
+                refresh_files.click(refresh_files_clicked_simple, [], refresh_files_output,
                                     queue=False, show_progress=False)
 
         state_is_generating = gr.State(False)


### PR DESCRIPTION
## Summary
- update `generate_cards` and `load_editor` to load preview images from `models/loras_previews`
- avoid invalid Textbox updates by simplifying the refresh logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524ca28f04832b8c8f0bcd645a8015