### PR TITLE
Add automatic test LoRA download

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -454,7 +454,9 @@ checkpoint_downloads = get_config_item_or_set_default(
 )
 lora_downloads = get_config_item_or_set_default(
     key='lora_downloads',
-    default_value={},
+    default_value={
+        'test_lora.safetensors': 'https://drive.google.com/uc?id=1trqzwfOwy8jF9aJ31hFDtkOakdktsWQR'
+    },
     validator=lambda x: isinstance(x, dict) and all(isinstance(k, str) and isinstance(v, str) for k, v in x.items()),
     expected_type=dict
 )

--- a/modules/model_loader.py
+++ b/modules/model_loader.py
@@ -3,6 +3,8 @@ import time
 from urllib.parse import urlparse
 from typing import Optional
 import urllib.error
+import sys
+import subprocess
 
 
 def load_file_from_url(
@@ -21,18 +23,28 @@ def load_file_from_url(
     os.makedirs(model_dir, exist_ok=True)
     if not file_name:
         parts = urlparse(url)
-        file_name = os.path.basename(parts.path)
+        file_name = os.path.basename(parts.path) or "download"
+
     cached_file = os.path.abspath(os.path.join(model_dir, file_name))
     if not os.path.exists(cached_file):
         print(f'Downloading: "{url}" to {cached_file}\n')
-        from torch.hub import download_url_to_file
-        for attempt in range(3):
+
+        if "drive.google.com" in url:
             try:
-                download_url_to_file(url, cached_file, progress=progress)
-                break
-            except urllib.error.HTTPError as e:
-                if attempt == 2:
-                    raise
-                print(f"Download failed with {e}. Retrying {attempt + 1}/3...")
-                time.sleep(5)
+                import gdown
+            except Exception:
+                subprocess.run([sys.executable, "-m", "pip", "install", "gdown"], check=True)
+                import gdown
+            gdown.download(url, cached_file, fuzzy=True)
+        else:
+            from torch.hub import download_url_to_file
+            for attempt in range(3):
+                try:
+                    download_url_to_file(url, cached_file, progress=progress)
+                    break
+                except urllib.error.HTTPError as e:
+                    if attempt == 2:
+                        raise
+                    print(f"Download failed with {e}. Retrying {attempt + 1}/3...")
+                    time.sleep(5)
     return cached_file

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -22,3 +22,4 @@ packaging==24.1
 rembg==2.0.57
 groundingdino-py==0.4.0
 segment_anything==1.0
+gdown==5.2.0


### PR DESCRIPTION
## Summary
- allow `load_file_from_url` to pull from Google Drive using gdown
- include example LoRA URL in config
- install gdown via requirements

## Testing
- `pip install -r requirements_versions.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525574be2c832b8c78e7027f4607c3