### PR TITLE
Reduce LoRA card dimensions

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1017,11 +1017,12 @@ footer {
     height:100%;
 }
 
+
 .extra-network-pane .card, .standalone-card-preview.card{
     display: inline-block;
     margin: 0.5rem;
-    width: 16rem;
-    height: 24rem;
+    width: 12rem;
+    height: 18rem;
     box-shadow: 0 0 5px rgba(128, 128, 128, 0.5);
     border-radius: 0.2rem;
     position: relative;


### PR DESCRIPTION
## Summary
- reduce the width and height of LoRA cards to make two cards fit per row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852edfcb114832b8606c97cc80b57f8