### PR TITLE
Fix JS function call in LoRA metadata editor

### DIFF
--- a/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
+++ b/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
@@ -216,7 +216,7 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
 
         self.button_add_tags.click(
             fn=None,
-            _js=f"function(){addTagsToPrompt(gradioApp().querySelector('#{self.tags_text.elem_id} textarea').value, '{self.tabname}')}",
+            _js=f"function(){{addTagsToPrompt(gradioApp().querySelector('#{self.tags_text.elem_id} textarea').value, '{self.tabname}')}}",
             inputs=[],
             outputs=[],
             show_progress=False,

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -252,7 +252,7 @@ def create_editor_ui(tabname: str, gallery, prompt):
 
         add_tags.click(
             fn=None,
-            _js=f"function(){addTagsToPrompt(gradioApp().querySelector('#{tags_text.elem_id} textarea').value, '{tabname}')}",
+            _js=f"function(){{addTagsToPrompt(gradioApp().querySelector('#{tags_text.elem_id} textarea').value, '{tabname}')}}",
             inputs=[],
             outputs=[],
             show_progress=False,


### PR DESCRIPTION
## Summary
- escape curly braces in `_js` handlers so Python doesn't try to interpret JS functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685325fe1b7c832b989d416f71d19be9