### PR TITLE
Fix training tag UI and preview layout

### DIFF
--- a/modules/lora_manager.py
+++ b/modules/lora_manager.py
@@ -101,8 +101,8 @@ def save_preview_image(path: str, image, fmt: str = 'PNG') -> None:
     image.save(preview_path, format=fmt)
 
 
-def build_tags(metadata: Dict) -> List[str]:
-    """Build an ordered tag list from metadata."""
+def build_tags(metadata: Dict) -> List[tuple[str, int]]:
+    """Return list of ``(tag, count)`` sorted by frequency."""
     tags: Dict[str, int] = {}
     freq = metadata.get('ss_tag_frequency', {})
     if hasattr(freq, 'items'):
@@ -110,6 +110,7 @@ def build_tags(metadata: Dict) -> List[str]:
             for tag, count in data.items():
                 tag = tag.strip()
                 tags[tag] = tags.get(tag, 0) + int(count)
+
     ordered = sorted(tags.items(), key=lambda x: x[1], reverse=True)
-    return [t[0] for t in ordered]
+    return ordered
 

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -49,6 +49,14 @@ find_preview = lora_utils.find_preview
 build_tags = lora_utils.build_tags
 
 
+def build_preview_html(path: str) -> str:
+    """Return HTML snippet for preview image."""
+    return (
+        f"<div class='card standalone-card-preview'>"
+        f"<img src=\"file={path}\" class=\"preview\"></div>"
+    )
+
+
 def build_filedata_table(path: str) -> str:
     """Return HTML table with basic file metadata."""
     try:
@@ -157,6 +165,11 @@ def load_editor(name):
         if not preview or not os.path.exists(preview):
             preview = default_preview
 
+    preview_html = (
+        f"<div class='card standalone-card-preview'>"
+        f"<img src=\"file={preview}\" class=\"preview\"></div>"
+    )
+
     return [
         name,
         desc,
@@ -168,7 +181,7 @@ def load_editor(name):
         weight,
         negative,
         notes,
-        preview,
+        preview_html,
     ]
 
 
@@ -213,7 +226,7 @@ def save_preview(name, *_):
     preview_path = os.path.join(preview_dir, f"{name}.preview.png")
     img_data.save(preview_path)
 
-    return {preview_image: gr.Image.update(value=preview_path)}
+    return {preview_image: gr.HTML.update(value=build_preview_html(preview_path))}
 
 
 def create_editor_ui(tabname: str, gallery, prompt):
@@ -227,7 +240,7 @@ def create_editor_ui(tabname: str, gallery, prompt):
                 desc = gr.Textbox(label="Description", lines=4)
                 filedata_html = gr.HTML()
                 sd_version = gr.Dropdown(['SD1', 'SD2', 'SDXL', 'Unknown'], value='Unknown', label='Stable Diffusion version')
-                taginfo = gr.HighlightedText(label='\U0001F4D0 Training dataset tags')
+                taginfo = gr.HighlightedText(label='Training dataset tags \U0001F4D0')
                 tags_text = gr.Textbox(visible=False)
                 add_tags = gr.Button('Add tags to prompt')
                 activation = gr.Textbox(label="Activation text")
@@ -235,12 +248,8 @@ def create_editor_ui(tabname: str, gallery, prompt):
                 negative = gr.Textbox(label="Negative prompt")
                 notes = gr.TextArea(label="Notes", lines=4)
             with gr.Column(scale=3, min_width=200):
-                preview_image = gr.Image(
-                    label="Preview",
-                    elem_id="lora_preview_image",
-                    show_label=False,
-                    interactive=False,
-                    height=192
+                preview_image = gr.HTML(
+                    elem_id="lora_preview_image"
                 )
         status = gr.HTML()
         with gr.Row():


### PR DESCRIPTION
## Summary
- return tag counts when building LoRA tags
- show dataset tags label with icon on the right
- generate preview HTML snippets and use them instead of gr.Image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532b902734832b8472aae821d87585