### PR TITLE
Fix LoRA metadata tags and preview layout

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1135,6 +1135,13 @@ footer {
     margin-top: 1.5em;
 }
 
+.edit-user-metadata img.preview{
+    width: 100%;
+    height: auto;
+    border-radius: 0.2rem;
+    object-fit: cover;
+}
+
 .popup-dialog {
     width: 56em;
     background: var(--body-background-fill) !important;

--- a/modules/NewLoraSystem/modules/ui_extra_networks_user_metadata.py
+++ b/modules/NewLoraSystem/modules/ui_extra_networks_user_metadata.py
@@ -79,15 +79,9 @@ class UserMetadataEditor:
             item["preview"] = preview_url
 
         if preview_url:
-            preview = f'''
-            <div class='card standalone-card-preview'>
-                <img src="{html.escape(preview_url)}" class="preview">
-            </div>
-            '''
+            return f'<img src="{html.escape(preview_url)}" class="preview">'
         else:
-            preview = "<div class='card standalone-card-preview'></div>"
-
-        return preview
+            return ''
 
     def relative_path(self, path):
         for parent_path in self.page.allowed_directories_for_previews():

--- a/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
+++ b/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
@@ -23,8 +23,22 @@ def build_tags(metadata):
     tags = {}
 
     ss_tag_frequency = metadata.get("ss_tag_frequency", {})
+
+    if isinstance(ss_tag_frequency, str):
+        try:
+            ss_tag_frequency = json.loads(ss_tag_frequency)
+        except Exception:
+            ss_tag_frequency = {}
+
     if ss_tag_frequency is not None and hasattr(ss_tag_frequency, 'items'):
         for _, tags_dict in ss_tag_frequency.items():
+            if isinstance(tags_dict, str):
+                try:
+                    tags_dict = json.loads(tags_dict)
+                except Exception:
+                    continue
+            if not hasattr(tags_dict, 'items'):
+                continue
             for tag, tag_count in tags_dict.items():
                 tag = tag.strip()
                 tags[tag] = tags.get(tag, 0) + int(tag_count)

--- a/modules/lora_manager.py
+++ b/modules/lora_manager.py
@@ -105,11 +105,24 @@ def build_tags(metadata: Dict) -> List[tuple[str, int]]:
     """Return list of ``(tag, count)`` sorted by frequency."""
     tags: Dict[str, int] = {}
     freq = metadata.get('ss_tag_frequency', {})
+
+    if isinstance(freq, str):
+        try:
+            freq = json.loads(freq)
+        except Exception:
+            freq = {}
+
     if hasattr(freq, 'items'):
         for _key, data in freq.items():
-            for tag, count in data.items():
-                tag = tag.strip()
-                tags[tag] = tags.get(tag, 0) + int(count)
+            if isinstance(data, str):
+                try:
+                    data = json.loads(data)
+                except Exception:
+                    continue
+            if hasattr(data, 'items'):
+                for tag, count in data.items():
+                    tag = tag.strip()
+                    tags[tag] = tags.get(tag, 0) + int(count)
 
     ordered = sorted(tags.items(), key=lambda x: x[1], reverse=True)
     return ordered


### PR DESCRIPTION
## Summary
- handle JSON strings when extracting LoRA tag frequency
- parse JSON tags in new LoRA system
- simplify preview HTML so image is not wrapped in card
- style preview image inside metadata editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853456c4a4c832b9c3bed268368e9ab