### PR TITLE
Fix LoRA editor layout

### DIFF
--- a/modules/NewLoraSystem/modules/ui_extra_networks_user_metadata.py
+++ b/modules/NewLoraSystem/modules/ui_extra_networks_user_metadata.py
@@ -46,7 +46,9 @@ class UserMetadataEditor:
         pass
 
     def create_default_editor_elems(self):
-        with gr.Row():
+        # Ensure that the title/description and preview image share the same
+        # row so they stay visually aligned.
+        with gr.Row(equal_height=True):
             with gr.Column(scale=2):
                 self.edit_name = gr.HTML(elem_classes="extra-network-name")
                 self.edit_description = gr.Textbox(label="Description", lines=4)


### PR DESCRIPTION
## Summary
- ensure LoRA editor fields and preview share the same row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534a6f535c832bbcf8e87a9408098c