### PR TITLE
Redesign metadata panel

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -1690,3 +1690,22 @@ body.resizing .resize-handle {
     padding: 0.2em 0.4em;
     border-radius: 3px;
 }
+
+.metadata-tags span .tag-count {
+    margin-left: 0.3em;
+    padding: 0 0.25em;
+    background: var(--button-secondary-background-fill-hover);
+    border-radius: 2px;
+}
+
+.preview-column {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 1em;
+}
+
+.lora-metadata-panel {
+    padding: 2em !important;
+}

--- a/modules/simple_lora_ui.py
+++ b/modules/simple_lora_ui.py
@@ -75,6 +75,18 @@ def build_filedata_table(path: str) -> str:
     return table
 
 
+def build_tags_html(tag_pairs: List[tuple[str, str]]) -> str:
+    """Return HTML for colored tag pills with counts."""
+    html_parts = ["<div class='metadata-tags'>"]
+    for tag, count in tag_pairs:
+        tag = html.escape(tag)
+        html_parts.append(
+            f"<span>{tag} <span class='tag-count'>{count}</span></span>"
+        )
+    html_parts.append("</div>")
+    return "".join(html_parts)
+
+
 def generate_cards():
     card_tpl = shared.html('extra-networks-card.html')
     copy_tpl = shared.html('extra-networks-copy-path-button.html')
@@ -149,6 +161,7 @@ def load_editor(name):
     tags_list = build_tags(metadata)
     tag_pairs = [(t, str(c)) for t, c in tags_list[:20]]
     tags_text = ', '.join([t for t, _ in tags_list])
+    tags_html = build_tags_html(tag_pairs)
 
     filedata = build_filedata_table(path)
     default_preview = os.path.join(
@@ -175,12 +188,12 @@ def load_editor(name):
         desc,
         filedata,
         sd_version,
-        tag_pairs,
+        tags_html,
         tags_text,
         activation,
+        notes,
         weight,
         negative,
-        notes,
         preview_html,
     ]
 
@@ -230,7 +243,7 @@ def save_preview(name, *_):
 
 
 def create_editor_ui(tabname: str, gallery, prompt):
-    with gr.Box(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata", elem_classes="edit-user-metadata") as box:
+    with gr.Box(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata", elem_classes="edit-user-metadata lora-metadata-panel") as box:
         name_in = gr.Textbox(visible=False, elem_id=f"{tabname}_lora_edit_user_metadata_name")
         button_edit = gr.Button("Edit user metadata", visible=False, elem_id=f"{tabname}_lora_edit_user_metadata_button")
         global preview_image
@@ -240,21 +253,21 @@ def create_editor_ui(tabname: str, gallery, prompt):
                 desc = gr.Textbox(label="Description", lines=4)
                 filedata_html = gr.HTML()
                 sd_version = gr.Dropdown(['SD1', 'SD2', 'SDXL', 'Unknown'], value='Unknown', label='Stable Diffusion version')
-                taginfo = gr.HighlightedText(label='Training dataset tags \U0001F4D0')
+                taginfo = gr.HTML()
                 tags_text = gr.Textbox(visible=False)
                 add_tags = gr.Button('Add tags to prompt')
                 activation = gr.Textbox(label="Activation text")
+                notes = gr.TextArea(label="Notes", lines=4)
                 weight = gr.Slider(label="Preferred weight", minimum=0.0, maximum=2.0, step=0.01, value=1.0)
                 negative = gr.Textbox(label="Negative prompt")
-                notes = gr.TextArea(label="Notes", lines=4)
-            with gr.Column(scale=3, min_width=200):
+            with gr.Column(scale=3, min_width=200, elem_classes="preview-column"):
                 preview_image = gr.HTML(
                     elem_id="lora_preview_image"
                 )
+                replace_preview = gr.Button('Replace preview', variant='primary')
         status = gr.HTML()
         with gr.Row():
             cancel = gr.Button('Cancel')
-            replace_preview = gr.Button('Replace preview', variant='primary')
             save = gr.Button('Save', variant='primary')
 
         cancel.click(fn=None, _js="closePopup")
@@ -270,7 +283,7 @@ def create_editor_ui(tabname: str, gallery, prompt):
         button_edit.click(
             fn=load_editor,
             inputs=[name_in],
-            outputs=[title, desc, filedata_html, sd_version, taginfo, tags_text, activation, weight, negative, notes, preview_image],
+            outputs=[title, desc, filedata_html, sd_version, taginfo, tags_text, activation, notes, weight, negative, preview_image],
         ).then(fn=lambda: gr.update(visible=True), inputs=[], outputs=[box])
 
         save.click(fn=save_metadata, inputs=[name_in, desc, activation, weight, negative, notes, sd_version], outputs=status).then(fn=None, _js='refreshLoraCards')


### PR DESCRIPTION
## Summary
- redesign LoRA metadata edit layout
- add tag count pill styling and preview column centering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685371f36548832b8f651ce68d7f6739