### PR TITLE
Refactor LoRA editor layout

### DIFF
--- a/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
+++ b/modules/NewLoraSystem/sd_forge_lora/ui_edit_user_metadata.py
@@ -197,22 +197,51 @@ class LoraUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataEditor)
         self.select_sd_version = gr.Dropdown(['SD1', 'SD2', 'SDXL', 'Unknown'], value='Unknown', label='Stable Diffusion version', interactive=True)
 
     def create_editor(self):
-        self.create_default_editor_elems()
+        with gr.Row(equal_height=True):
+            with gr.Column(scale=7):
+                self.edit_name = gr.HTML(elem_classes="extra-network-name")
+                self.edit_description = gr.Textbox(label="Description", lines=4)
+                self.html_filedata = gr.HTML()
 
-        self.taginfo = gr.HighlightedText(label="Training dataset tags")
-        self.button_add_tags = gr.Button('Use these tags in the prompt', visible=False)
-        self.tags_text = gr.Textbox(visible=False)
-        self.edit_activation_text = gr.Text(label='Activation text', info="Will be added to prompt along with Lora")
-        self.slider_preferred_weight = gr.Slider(label='Preferred weight', info="Set to 0 to disable", minimum=0.0, maximum=2.0, step=0.01)
-        self.edit_negative_text = gr.Text(label='Negative prompt', info="Will be added to negative prompts")
-        with gr.Row() as row_random_prompt:
-            with gr.Column(scale=8):
-                random_prompt = gr.Textbox(label='Random prompt', lines=4, max_lines=4, interactive=False)
+                # Metadata fields
+                self.select_sd_version = gr.Dropdown([
+                    'SD1', 'SD2', 'SDXL', 'Unknown'
+                ], value='Unknown', label='Stable Diffusion version', interactive=True)
 
-            with gr.Column(scale=1, min_width=120):
-                generate_random_prompt = gr.Button('Generate', size="lg", scale=1)
+                self.taginfo = gr.HighlightedText(label="Training dataset tags 📐")
+                self.button_add_tags = gr.Button('Use these tags in the prompt', visible=False)
+                self.tags_text = gr.Textbox(visible=False)
+                self.edit_activation_text = gr.Text(
+                    label='Activation text',
+                    info="Will be added to prompt along with Lora"
+                )
+                self.slider_preferred_weight = gr.Slider(
+                    label='Preferred weight',
+                    info="Set to 0 to disable",
+                    minimum=0.0,
+                    maximum=2.0,
+                    step=0.01
+                )
+                self.edit_negative_text = gr.Text(
+                    label='Negative prompt',
+                    info="Will be added to negative prompts"
+                )
+                with gr.Row() as row_random_prompt:
+                    with gr.Column(scale=8):
+                        random_prompt = gr.Textbox(
+                            label='Random prompt',
+                            lines=4,
+                            max_lines=4,
+                            interactive=False
+                        )
 
-        self.edit_notes = gr.TextArea(label='Notes', lines=4)
+                    with gr.Column(scale=1, min_width=120):
+                        generate_random_prompt = gr.Button('Generate', size="lg", scale=1)
+
+                self.edit_notes = gr.TextArea(label='Notes', lines=4)
+
+            with gr.Column(scale=3, min_width=0):
+                self.html_preview = gr.Image(value=None, interactive=False, show_label=False, height=192)
 
         generate_random_prompt.click(fn=self.generate_random_prompt, inputs=[self.edit_name_input], outputs=[random_prompt], show_progress=False)
 


### PR DESCRIPTION
## Summary
- use a two-column layout in the new LoRA metadata editor
- keep preview image in its own 30% column
- show training dataset tags with a 📐 label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853771dc37c832b87043d80b882abac