### PR TITLE
Add always-visible custom aspect ratio inputs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -160,6 +160,10 @@ div:has(> #positive_prompt) {
     flex: 0 0 100%;
 }
 
+#custom_ratio_column {
+    flex: 0 0 100%;
+}
+
 /* shape variations */
 
 .square-ratio {

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -74,7 +74,11 @@ onUiLoaded(async () => {
 
     let aspectContainer = document.querySelector('.aspect_ratios');
     if (aspectContainer && !aspectContainer.querySelector('.aspect_ratios_group')) {
+        let customColumn = aspectContainer.querySelector('#custom_ratio_column');
         let labels = Array.from(aspectContainer.querySelectorAll('label'));
+        if (customColumn) {
+            labels = labels.filter(l => !customColumn.contains(l));
+        }
         aspectContainer.innerHTML = '';
         const groups = [
             {title: 'Square', count: 2, cls: 'square-ratio'},
@@ -113,6 +117,9 @@ onUiLoaded(async () => {
             }
             aspectContainer.appendChild(grp);
         });
+        if (customColumn) {
+            aspectContainer.appendChild(customColumn);
+        }
     }
 
     let styleSelections = document.querySelector('.style_selections');

--- a/webui.py
+++ b/webui.py
@@ -645,19 +645,16 @@ with shared.gradio_root:
                                                        info='width × height',
                                                        elem_classes='aspect_ratios')
 
-                    with gr.Column(visible=False, elem_id='custom_ratio_column') as custom_ratio_column:
+                    with gr.Column(visible=True, elem_id='custom_ratio_column') as custom_ratio_column:
                         custom_width = gr.Number(label='Width', value=1024, minimum=64, maximum=2048, step=8)
                         custom_height = gr.Number(label='Height', value=1024, minimum=64, maximum=2048, step=8)
 
                     def _on_ratio_change(val):
                         if val != 'Custom':
                             modules.config.set_config_value('default_aspect_ratio', val)
-                            return gr.update(visible=False)
-                        return gr.update(visible=True)
 
                     aspect_ratios_selection.change(_on_ratio_change,
                                                   inputs=aspect_ratios_selection,
-                                                  outputs=custom_ratio_column,
                                                   queue=False, show_progress=False,
                                                   _js='(x)=>{refresh_aspect_ratios_label(x);}')
 


### PR DESCRIPTION
## Summary
- keep the custom width/height fields for aspect ratios visible
- group aspect ratios without disturbing the custom inputs
- adjust layout so custom inputs use full width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aeef90f4832b9f0cd3cd2c9b8048