### PR TITLE
Add custom aspect ratio controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,6 +130,10 @@ div:has(> #positive_prompt) {
     align-items: center;
 }
 
+.aspect_ratios_group label.custom_ratio_label {
+    flex: 0 0 100%;
+}
+
 .aspect_ratios_group > div:first-child {
     width: 100%;
     font-weight: bold;

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -79,7 +79,8 @@ onUiLoaded(async () => {
         const groups = [
             {title: 'Square', count: 2, cls: 'square-ratio'},
             {title: 'Portrait', count: 4, cls: 'portrait-ratio'},
-            {title: 'Landscape', count: labels.length - 6, cls: 'landscape-ratio'}
+            {title: 'Landscape', count: labels.length - 7, cls: 'landscape-ratio'},
+            {title: 'Custom', count: 1, cls: 'custom-ratio'}
         ];
         let idx = 0;
         groups.forEach(g => {
@@ -93,6 +94,9 @@ onUiLoaded(async () => {
             for (let i = 0; i < g.count; i++) {
                 if (labels[idx]) {
                     let label = labels[idx];
+                    if (g.title === 'Custom') {
+                        label.classList.add('custom_ratio_label');
+                    }
                     let span = label.querySelector('span');
                     if (span) {
                         let text = span.textContent;

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -68,6 +68,8 @@ class AsyncTask:
         self.original_steps = self.steps
 
         self.aspect_ratios_selection = args.pop()
+        self.custom_width = int(args.pop())
+        self.custom_height = int(args.pop())
         self.image_number = args.pop()
         self.output_format = args.pop()
         self.seed = int(args.pop())
@@ -1256,6 +1258,9 @@ def worker():
         tiled = False
 
         width, height = modules.util.parse_resolution_label(async_task.aspect_ratios_selection)
+        if width == 0 or height == 0 or async_task.aspect_ratios_selection.lower().startswith('custom'):
+            width = async_task.custom_width
+            height = async_task.custom_height
 
         skip_prompt_processing = False
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -848,6 +848,7 @@ def add_ratio(x):
 
 default_aspect_ratio = add_ratio(default_aspect_ratio)
 available_aspect_ratios_labels = [add_ratio(x) for x in available_aspect_ratios]
+available_aspect_ratios_labels.append('Custom')
 
 
 # Only write config in the first launch.

--- a/webui.py
+++ b/webui.py
@@ -43,7 +43,7 @@ def get_task(*args):
     args = list(args)
     args.pop(0)
 
-    lora_insert_index = 16  # after base_model, refiner_model, refiner_switch
+    lora_insert_index = 18  # after base_model, refiner_model, refiner_switch
     lora_json = "[]"
     if len(args) > lora_insert_index:
         lora_json = args.pop(lora_insert_index)
@@ -643,6 +643,8 @@ with shared.gradio_root:
                                                        value=modules.config.default_aspect_ratio,
                                                        info='width × height',
                                                        elem_classes='aspect_ratios')
+                    custom_width = gr.Number(label='Width', value=1024)
+                    custom_height = gr.Number(label='Height', value=1024)
 
                     aspect_ratios_selection.change(lambda x: modules.config.set_config_value('default_aspect_ratio', x),
                                                   inputs=aspect_ratios_selection, queue=False, show_progress=False,
@@ -1079,7 +1081,8 @@ with shared.gradio_root:
         ctrls = [currentTask, generate_image_grid]
         ctrls += [
             prompt, negative_prompt, style_selections, csv_style,
-            performance_selection, aspect_ratios_selection, image_number, output_format, seed_actual,
+            performance_selection, aspect_ratios_selection, custom_width, custom_height,
+            image_number, output_format, seed_actual,
             read_wildcards_in_order, sharpness, guidance_scale
         ]
 


### PR DESCRIPTION
## Summary
- add `Custom` label to aspect ratios and keep custom width and height inputs visible
- style custom aspect ratio label to span full width
- display custom option in aspect ratio groups on load
- pass custom width/height into AsyncTask and use when custom option selected
- adjust control argument ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b25c52e8832bb6c50aea262b222c