### PR TITLE
Arrange custom width/height next to Custom option

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -538,3 +538,13 @@ div:has(> #positive_prompt) {
   word-break: break-word;
 }
 
+/* arrange custom width and height next to Custom option */
+#custom-size-fields {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+}
+#custom-size-fields > div {
+  flex: 1;
+}
+

--- a/javascript/viewer.js
+++ b/javascript/viewer.js
@@ -132,4 +132,17 @@ onUiLoaded(async () => {
     inputs.forEach(function (input) {
         input.style.marginTop = '12px';
     });
+
+    // place custom width and height fields next to the Custom ratio option
+    const customLabel = document.querySelector('.aspect_ratios label.custom_ratio_label');
+    const widthElem = document.getElementById('custom-width');
+    const heightElem = document.getElementById('custom-height');
+    if (customLabel && widthElem && heightElem) {
+        const parent = customLabel.parentElement;
+        const container = document.createElement('div');
+        container.id = 'custom-size-fields';
+        container.appendChild(widthElem);
+        container.appendChild(heightElem);
+        parent.insertBefore(container, customLabel.nextSibling);
+    }
 });

--- a/webui.py
+++ b/webui.py
@@ -643,8 +643,8 @@ with shared.gradio_root:
                                                        value=modules.config.default_aspect_ratio,
                                                        info='width × height',
                                                        elem_classes='aspect_ratios')
-                    custom_width = gr.Number(label='Width', value=1024)
-                    custom_height = gr.Number(label='Height', value=1024)
+                    custom_width = gr.Number(label='Width', value=1024, elem_id='custom-width')
+                    custom_height = gr.Number(label='Height', value=1024, elem_id='custom-height')
 
                     aspect_ratios_selection.change(lambda x: modules.config.set_config_value('default_aspect_ratio', x),
                                                   inputs=aspect_ratios_selection, queue=False, show_progress=False,


### PR DESCRIPTION
## Summary
- show width and height number boxes inside the aspect ratio control
- create flex row for custom size selection
- move inputs into the custom label using JS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854b7e8c3f8832bb0614bf2f6c0b0e2