### PR TITLE
Align custom width and height controls

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -643,8 +643,9 @@ with shared.gradio_root:
                                                        value=modules.config.default_aspect_ratio,
                                                        info='width × height',
                                                        elem_classes='aspect_ratios')
-                    custom_width = gr.Number(label='Width', value=1024)
-                    custom_height = gr.Number(label='Height', value=1024)
+                    with gr.Row():
+                        custom_width = gr.Number(label='Width', value=1024)
+                        custom_height = gr.Number(label='Height', value=1024)
 
                     aspect_ratios_selection.change(lambda x: modules.config.set_config_value('default_aspect_ratio', x),
                                                   inputs=aspect_ratios_selection, queue=False, show_progress=False,


### PR DESCRIPTION
## Summary
- align custom width and height inputs in the settings tab

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6854c6a09a98832b93f58e2e6988454d