### PR TITLE
Add padding to aspect ratios header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -139,6 +139,7 @@ div:has(> #positive_prompt) {
     width: 100%;
     font-weight: bold;
     margin-bottom: 2px;
+    padding-left: 6px;
 }
 
 /* Hide internal file component used for downloading the last image */


### PR DESCRIPTION
## Summary
- tweak `css/style.css` to indent the aspect ratios header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855563939cc832baaf913b364e7606d