### PR TITLE
Adjust padding for accordion headers

### DIFF
--- a/modules/NewLoraSystem/css/style.css
+++ b/modules/NewLoraSystem/css/style.css
@@ -176,6 +176,10 @@ div.block.gradio-accordion {
     padding: 8px 8px;
 }
 
+div.block.gradio-accordion summary {
+    padding-left: 6px;
+}
+
 
 
 /* txt2img/img2img specific */


### PR DESCRIPTION
## Summary
- tweak accordion CSS to push summary text a bit to the right

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555a3d6ddc832bafea1132abefec47