### PR TITLE
Fix ADetailer UI accordion

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -709,11 +709,26 @@ with shared.gradio_root:
                                                      elem_classes=['performance_selection'],
                                                      elem_id='performance-selection')
 
-                    with gr.Accordion(label='Adetailer', open=False, elem_id='adetailer-accordion'):
-                        adetailer_enable = gr.Checkbox(label='Enable ADetailer',
-                                                      value=modules.config.default_adetailer_enable)
-                        adetailer_enable.change(lambda x: modules.config.set_config_value('default_adetailer_enable', x),
-                                                inputs=adetailer_enable, queue=False, show_progress=False)
+                with gr.Accordion(label='Adetailer', open=False, elem_id='adetailer-accordion'):
+                    adetailer_enable = gr.Checkbox(label='Enable ADetailer',
+                                                  value=modules.config.default_adetailer_enable,
+                                                  elem_id='adetailer-enable')
+                    with gr.Group(visible=modules.config.default_adetailer_enable) as adetailer_group:
+                        adetailer_model = gr.Dropdown(label='ADetailer Model',
+                                                     choices=list(adetailer_module.MODEL_URLS.keys()),
+                                                     value=modules.config.default_adetailer_model)
+                        with gr.Tabs():
+                            with gr.Tab('Face'):
+                                ad_face_conf = gr.Slider(label='Face Confidence', minimum=0.0, maximum=1.0, step=0.01, value=0.3)
+                            with gr.Tab('Body'):
+                                ad_body_conf = gr.Slider(label='Body Confidence', minimum=0.0, maximum=1.0, step=0.01, value=0.3)
+
+                    adetailer_enable.change(lambda x: gr.update(visible=x), inputs=adetailer_enable,
+                                            outputs=adetailer_group, queue=False, show_progress=False)
+                    adetailer_enable.change(lambda x: modules.config.set_config_value('default_adetailer_enable', x),
+                                            inputs=adetailer_enable, queue=False, show_progress=False)
+                    adetailer_model.change(lambda x: modules.config.set_config_value('default_adetailer_model', x),
+                                           inputs=adetailer_model, queue=False, show_progress=False)
 
                 def update_history_link():
                     if args_manager.args.disable_image_log:


### PR DESCRIPTION
## Summary
- move ADetailer controls outside of the Preset accordion
- show detection options when ADetailer is enabled

## Testing
- `pytest tests/test_extra_utils.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68559fabd510832b9483594cc79306a2