### PR TITLE
Enable basic Adetailer integration

### DIFF
--- a/adetailer/__init__.py
+++ b/adetailer/__init__.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+import sys
+
+sys.modules.setdefault("adetailer", sys.modules[__name__])
+for sub in ("args", "common", "mediapipe", "ultralytics"):
+    sys.modules[f"adetailer.{sub}"] = sys.modules[__name__]
+
+_base = import_module("modules.adetailer.vendor_adetailer")
+
+for sub in ("args", "common", "mediapipe", "ultralytics"):
+    sys.modules[f"adetailer.{sub}"] = import_module(f"modules.adetailer.vendor_adetailer.{sub}")
+
+__all__ = list(getattr(_base, "__all__", []))
+globals().update({name: getattr(_base, name) for name in __all__})

--- a/modules/adetailer/adetailer.py
+++ b/modules/adetailer/adetailer.py
@@ -1,6 +1,6 @@
 import os
-from typing import Optional, TYPE_CHECKING
-from PIL import Image
+from typing import Optional, TYPE_CHECKING, Iterable
+from PIL import Image, ImageFilter
 
 from modules.model_loader import load_file_from_url
 import modules.config as config
@@ -11,6 +11,14 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 MODEL_URLS = {
     "face_yolov8n.pt": "https://huggingface.co/Bingsu/adetailer/resolve/main/face_yolov8n.pt",
     "face_yolov8s.pt": "https://huggingface.co/Bingsu/adetailer/resolve/main/face_yolov8s.pt",
+    "hand_yolov8n.pt": "https://huggingface.co/Bingsu/adetailer/resolve/main/hand_yolov8n.pt",
+    "person_yolov8n-seg.pt": "https://huggingface.co/Bingsu/adetailer/resolve/main/person_yolov8n-seg.pt",
+    "person_yolov8s-seg.pt": "https://huggingface.co/Bingsu/adetailer/resolve/main/person_yolov8s-seg.pt",
+    "yolov8x-worldv2.pt": "https://huggingface.co/Bingsu/yolo-world-mirror/resolve/main/yolov8x-worldv2.pt",
+    "mediapipe_face_full": None,
+    "mediapipe_face_short": None,
+    "mediapipe_face_mesh": None,
+    "mediapipe_face_mesh_eyes_only": None,
 }
 
 
@@ -25,20 +33,35 @@ def ensure_model(model_name: str, url: Optional[str] = None) -> str:
     return model_path
 
 
-def detect(image: Image.Image, model_name: Optional[str] = None) -> "PredictOutput":
-    from .vendor_adetailer import ultralytics_predict
-
+def detect(image: Image.Image, model_name: Optional[str] = None, confidence: float = 0.3, classes: str = "") -> "PredictOutput":
+    from .vendor_adetailer import ultralytics_predict, mediapipe_predict
     model_name = model_name or config.default_adetailer_model
+    if model_name.startswith("mediapipe"):
+        return mediapipe_predict(model_name, image, confidence=confidence)
     model_path = ensure_model(model_name)
-    return ultralytics_predict(model_path, image, device="cpu")
+    return ultralytics_predict(model_path, image, confidence=confidence, device="cpu", classes=classes)
 
 
-def apply_adetailer(image: Image.Image) -> Image.Image:
+def apply_adetailer(image: Image.Image, models: Iterable[str] | None = None) -> Image.Image:
+    """Apply ADetailer to ``image`` using the given models.
+
+    This implementation is simplified and applies a detail filter to detected regions.
+    """
+
     if not config.default_adetailer_enable:
         return image
-    try:
-        result = detect(image)
-        print(f"[ADetailer] {len(result.masks)} masks detected using {config.default_adetailer_model}")
-    except Exception as e:  # pragma: no cover - best effort
-        print(f"[ADetailer] failed: {e}")
-    return image
+
+    models = list(models or [config.default_adetailer_model])
+    result_img = image.copy()
+
+    for model in models:
+        try:
+            result = detect(result_img, model)
+            print(f"[ADetailer] {len(result.masks)} masks detected using {model}")
+            for mask in getattr(result, "masks", []):
+                filtered = result_img.filter(ImageFilter.DETAIL)
+                result_img.paste(filtered, mask=mask)
+        except Exception as e:  # pragma: no cover - best effort
+            print(f"[ADetailer] failed on {model}: {e}")
+
+    return result_img

--- a/webui.py
+++ b/webui.py
@@ -26,6 +26,7 @@ from modules.auth import auth_enabled, check_auth
 from modules.util import is_json
 from modules import simple_lora_ui
 from modules.adetailer import adetailer as adetailer_module
+from modules.adetailer.ui import adui, WebuiInfo
 
 shared.prompt_styles = styles.StyleDatabase(["styles.csv", "styles_integrated.csv"])
 
@@ -710,25 +711,16 @@ with shared.gradio_root:
                                                      elem_id='performance-selection')
 
                 with gr.Accordion(label='Adetailer', open=False, elem_id='adetailer-accordion'):
-                    adetailer_enable = gr.Checkbox(label='Enable ADetailer',
-                                                  value=modules.config.default_adetailer_enable,
-                                                  elem_id='adetailer-enable')
-                    with gr.Group(visible=modules.config.default_adetailer_enable) as adetailer_group:
-                        adetailer_model = gr.Dropdown(label='ADetailer Model',
-                                                     choices=list(adetailer_module.MODEL_URLS.keys()),
-                                                     value=modules.config.default_adetailer_model)
-                        with gr.Tabs():
-                            with gr.Tab('Face'):
-                                ad_face_conf = gr.Slider(label='Face Confidence', minimum=0.0, maximum=1.0, step=0.01, value=0.3)
-                            with gr.Tab('Body'):
-                                ad_body_conf = gr.Slider(label='Body Confidence', minimum=0.0, maximum=1.0, step=0.01, value=0.3)
-
-                    adetailer_enable.change(lambda x: gr.update(visible=x), inputs=adetailer_enable,
-                                            outputs=adetailer_group, queue=False, show_progress=False)
-                    adetailer_enable.change(lambda x: modules.config.set_config_value('default_adetailer_enable', x),
-                                            inputs=adetailer_enable, queue=False, show_progress=False)
-                    adetailer_model.change(lambda x: modules.config.set_config_value('default_adetailer_model', x),
-                                           inputs=adetailer_model, queue=False, show_progress=False)
+                    webui_info = WebuiInfo(
+                        ad_model_list=list(adetailer_module.MODEL_URLS.keys()),
+                        sampler_names=[],
+                        scheduler_names=[],
+                        t2i_button=generate_button,
+                        i2i_button=generate_button,
+                        checkpoints_list=[],
+                        vae_list=[],
+                    )
+                    ad_components, _ = adui(4, False, webui_info)
 
                 def update_history_link():
                     if args_manager.args.disable_image_log:


### PR DESCRIPTION
## Summary
- expose vendor package as `adetailer`
- add simplified detection-based implementation in `modules.adetailer`
- show ADetailer tabs in the UI

## Testing
- `pytest tests/test_adetailer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a6d9f73c832b9cc6146c634df62f