### PR TITLE
Fix ADetailer import paths

### DIFF
--- a/modules/adetailer/aaaaaa/traceback.py
+++ b/modules/adetailer/aaaaaa/traceback.py
@@ -13,8 +13,8 @@ from rich.table import Table
 from rich.traceback import Traceback
 from typing_extensions import ParamSpec
 
-from adetailer.__version__ import __version__
-from adetailer.args import ADetailerArgs
+from ..vendor_adetailer.__version__ import __version__
+from ..vendor_adetailer.args import ADetailerArgs
 
 
 def processing(*args: Any) -> dict[str, Any]:

--- a/modules/adetailer/aaaaaa/ui.py
+++ b/modules/adetailer/aaaaaa/ui.py
@@ -9,8 +9,8 @@ from typing import Any
 import gradio as gr
 
 from aaaaaa.conditional import InputAccordion
-from adetailer import ADETAILER, __version__
-from adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
+from ..vendor_adetailer import ADETAILER, __version__
+from ..vendor_adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
 from controlnet_ext import controlnet_exists, controlnet_type, get_cn_models
 
 if controlnet_type == "forge":

--- a/modules/adetailer/scripts/!adetailer.py
+++ b/modules/adetailer/scripts/!adetailer.py
@@ -33,14 +33,14 @@ from aaaaaa.p_method import (
 )
 from aaaaaa.traceback import rich_traceback
 from modules.adetailer.ui import WebuiInfo, adui, ordinal, suffix
-from adetailer import (
+from ..vendor_adetailer import (
     ADETAILER,
     __version__,
     get_models,
     mediapipe_predict,
     ultralytics_predict,
 )
-from adetailer.args import (
+from ..vendor_adetailer.args import (
     BBOX_SORTBY,
     BUILTIN_SCRIPT,
     INPAINT_BBOX_MATCH_MODES,
@@ -49,8 +49,8 @@ from adetailer.args import (
     InpaintBBoxMatchMode,
     SkipImg2ImgOrig,
 )
-from adetailer.common import PredictOutput, ensure_pil_image, safe_mkdir
-from adetailer.mask import (
+from ..vendor_adetailer.common import PredictOutput, ensure_pil_image, safe_mkdir
+from ..vendor_adetailer.mask import (
     filter_by_ratio,
     filter_k_by,
     has_intersection,
@@ -58,7 +58,7 @@ from adetailer.mask import (
     mask_preprocess,
     sort_bboxes,
 )
-from adetailer.opts import dynamic_denoise_strength, optimal_crop_size
+from ..vendor_adetailer.opts import dynamic_denoise_strength, optimal_crop_size
 from controlnet_ext import (
     CNHijackRestore,
     ControlNetExt,

--- a/modules/adetailer/tests/test_args.py
+++ b/modules/adetailer/tests/test_args.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from adetailer.args import ALL_ARGS, ADetailerArgs
+from modules.adetailer.vendor_adetailer.args import ALL_ARGS, ADetailerArgs
 
 
 def test_all_args() -> None:

--- a/modules/adetailer/tests/test_common.py
+++ b/modules/adetailer/tests/test_common.py
@@ -1,7 +1,10 @@
 import numpy as np
 from PIL import Image, ImageDraw
 
-from adetailer.common import create_bbox_from_mask, create_mask_from_bbox
+from modules.adetailer.vendor_adetailer.common import (
+    create_bbox_from_mask,
+    create_mask_from_bbox,
+)
 
 
 def test_create_mask_from_bbox():

--- a/modules/adetailer/tests/test_mask.py
+++ b/modules/adetailer/tests/test_mask.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 from PIL import Image, ImageDraw
 
-from adetailer.mask import (
+from modules.adetailer.vendor_adetailer.mask import (
     bbox_area,
     dilate_erode,
     has_intersection,

--- a/modules/adetailer/tests/test_mediapipe.py
+++ b/modules/adetailer/tests/test_mediapipe.py
@@ -1,7 +1,7 @@
 import pytest
 from PIL import Image
 
-from adetailer.mediapipe import mediapipe_predict
+from modules.adetailer.vendor_adetailer.mediapipe import mediapipe_predict
 
 
 @pytest.mark.parametrize(

--- a/modules/adetailer/tests/test_opts.py
+++ b/modules/adetailer/tests/test_opts.py
@@ -5,7 +5,10 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from adetailer.opts import dynamic_denoise_strength, optimal_crop_size
+from modules.adetailer.vendor_adetailer.opts import (
+    dynamic_denoise_strength,
+    optimal_crop_size,
+)
 
 
 @pytest.mark.parametrize(

--- a/modules/adetailer/tests/test_ultralytics.py
+++ b/modules/adetailer/tests/test_ultralytics.py
@@ -2,7 +2,7 @@ import pytest
 from huggingface_hub import hf_hub_download
 from PIL import Image
 
-from adetailer.ultralytics import ultralytics_predict
+from modules.adetailer.vendor_adetailer.ultralytics import ultralytics_predict
 
 
 @pytest.mark.parametrize(

--- a/modules/adetailer/ui.py
+++ b/modules/adetailer/ui.py
@@ -9,8 +9,8 @@ from typing import Any
 import gradio as gr
 
 from aaaaaa.conditional import InputAccordion
-from adetailer import ADETAILER, __version__
-from adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
+from .vendor_adetailer import ADETAILER, __version__
+from .vendor_adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
 from controlnet_ext import controlnet_exists, controlnet_type, get_cn_models
 
 if controlnet_type == "forge":

--- a/modules/adetailer/vendor_adetailer/mask.py
+++ b/modules/adetailer/vendor_adetailer/mask.py
@@ -9,8 +9,8 @@ import cv2
 import numpy as np
 from PIL import Image, ImageChops
 
-from adetailer.args import MASK_MERGE_INVERT
-from adetailer.common import PredictOutput, ensure_pil_image
+from .args import MASK_MERGE_INVERT
+from .common import PredictOutput, ensure_pil_image
 
 
 class SortBy(IntEnum):

--- a/modules/adetailer/vendor_adetailer/mediapipe.py
+++ b/modules/adetailer/vendor_adetailer/mediapipe.py
@@ -6,8 +6,8 @@ import cv2
 import numpy as np
 from PIL import Image, ImageDraw
 
-from adetailer import PredictOutput
-from adetailer.common import create_bbox_from_mask, create_mask_from_bbox
+from . import PredictOutput
+from .common import create_bbox_from_mask, create_mask_from_bbox
 
 
 def mediapipe_predict(

--- a/modules/adetailer/vendor_adetailer/ultralytics.py
+++ b/modules/adetailer/vendor_adetailer/ultralytics.py
@@ -7,8 +7,8 @@ import cv2
 from PIL import Image
 from torchvision.transforms.functional import to_pil_image
 
-from adetailer import PredictOutput
-from adetailer.common import create_mask_from_bbox
+from . import PredictOutput
+from .common import create_mask_from_bbox
 
 if TYPE_CHECKING:
     import torch


### PR DESCRIPTION
## Summary
- fix relative imports for ADetailer modules
- update tests to use new import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d7220898832bba14f45217a9db4f