### PR TITLE
Improve ADetailer optional dependencies

### DIFF
--- a/modules/adetailer/vendor_adetailer/common.py
+++ b/modules/adetailer/vendor_adetailer/common.py
@@ -11,7 +11,28 @@ from typing import Any, Generic, Optional, TypeVar
 from huggingface_hub import hf_hub_download
 from PIL import Image, ImageDraw
 from rich import print  # noqa: A004  Shadowing built-in 'print'
-from torchvision.transforms.functional import to_pil_image
+try:  # pragma: no cover - optional dependency
+    from torchvision.transforms.functional import to_pil_image
+except Exception:  # pragma: no cover - best effort fallback
+    import numpy as np
+    from PIL import Image as _Image
+
+    def to_pil_image(image, mode=None):
+        """Basic fallback for torchvision's to_pil_image."""
+        if hasattr(image, "detach"):
+            image = image.detach().cpu()
+        if hasattr(image, "numpy"):
+            image = image.numpy()
+        if isinstance(image, np.ndarray):
+            if image.ndim == 3 and image.shape[0] in (1, 3):
+                image = image.transpose(1, 2, 0)
+            if image.dtype != np.uint8:
+                image = (
+                    image * 255 if image.max() <= 1 else image
+                ).clip(0, 255).astype(np.uint8)
+        else:
+            image = np.asarray(image)
+        return _Image.fromarray(image, mode=mode)
 
 REPO_ID = "Bingsu/adetailer"
 

--- a/modules/adetailer/vendor_adetailer/ultralytics.py
+++ b/modules/adetailer/vendor_adetailer/ultralytics.py
@@ -5,7 +5,25 @@ from typing import TYPE_CHECKING
 
 import cv2
 from PIL import Image
-from torchvision.transforms.functional import to_pil_image
+try:  # pragma: no cover - optional dependency
+    from torchvision.transforms.functional import to_pil_image
+except Exception:  # pragma: no cover - best effort fallback
+    import numpy as np
+    from PIL import Image as _Image
+
+    def to_pil_image(tensor, mode=None):
+        if hasattr(tensor, "detach"):
+            tensor = tensor.detach().cpu()
+        if hasattr(tensor, "numpy"):
+            tensor = tensor.numpy()
+        if isinstance(tensor, np.ndarray):
+            if tensor.ndim == 3 and tensor.shape[0] in (1, 3):
+                tensor = tensor.transpose(1, 2, 0)
+            if tensor.dtype != np.uint8:
+                tensor = (tensor * 255 if tensor.max() <= 1 else tensor).clip(0, 255).astype(np.uint8)
+        else:
+            tensor = np.asarray(tensor)
+        return _Image.fromarray(tensor, mode=mode)
 
 from . import PredictOutput
 from .common import create_mask_from_bbox


### PR DESCRIPTION
## Summary
- make torchvision optional for ADetailer helpers
- ensure tests pass with minimal dependencies
- add robust fallback for to_pil_image when torchvision is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f081e59c832ba464894f61bb9647