### PR TITLE
Add debug output for Mediapipe mask pipeline

### DIFF
--- a/modules/adetailer/vendor_adetailer/mask.py
+++ b/modules/adetailer/vendor_adetailer/mask.py
@@ -217,20 +217,30 @@ def filter_by_ratio(
     pred: PredictOutput[T], low: float, high: float
 ) -> PredictOutput[T]:
     if not pred.bboxes:
+        print("[DEBUG] filter_by_ratio: no bboxes to filter")
         return pred
 
     w, h = pred.preview.size
     orig_area = w * h
     items = len(pred.bboxes)
-    idx = [i for i in range(items) if is_in_ratio(pred.bboxes[i], low, high, orig_area)]
+    idx = []
+    for i in range(items):
+        area_ratio = bbox_area(pred.bboxes[i]) / orig_area
+        print(f"[DEBUG] bbox {i} area ratio: {area_ratio:.4f}")
+        if is_in_ratio(pred.bboxes[i], low, high, orig_area):
+            idx.append(i)
+        else:
+            print(f"[DEBUG] bbox {i} filtered out by ratio")
     pred.bboxes = [pred.bboxes[i] for i in idx]
     pred.masks = [pred.masks[i] for i in idx]
     pred.confidences = [pred.confidences[i] for i in idx]
+    print(f"[DEBUG] filter_by_ratio kept {len(pred.bboxes)}/{items} bboxes")
     return pred
 
 
 def filter_k_largest(pred: PredictOutput[T], k: int = 0) -> PredictOutput[T]:
     if not pred.bboxes or k == 0:
+        print("[DEBUG] filter_k_largest: nothing to filter")
         return pred
     areas = [bbox_area(bbox) for bbox in pred.bboxes]
     idx = np.argsort(areas)[-k:]
@@ -238,23 +248,27 @@ def filter_k_largest(pred: PredictOutput[T], k: int = 0) -> PredictOutput[T]:
     pred.bboxes = [pred.bboxes[i] for i in idx]
     pred.masks = [pred.masks[i] for i in idx]
     pred.confidences = [pred.confidences[i] for i in idx]
+    print(f"[DEBUG] filter_k_largest kept {len(idx)}/{len(areas)} bboxes")
     return pred
 
 
 def filter_k_most_confident(pred: PredictOutput[T], k: int = 0) -> PredictOutput[T]:
     if not pred.bboxes or not pred.confidences or k == 0:
+        print("[DEBUG] filter_k_most_confident: nothing to filter")
         return pred
     idx = np.argsort(pred.confidences)[-k:]
     idx = idx[::-1]
     pred.bboxes = [pred.bboxes[i] for i in idx]
     pred.masks = [pred.masks[i] for i in idx]
     pred.confidences = [pred.confidences[i] for i in idx]
+    print(f"[DEBUG] filter_k_most_confident kept {len(idx)}/{len(pred.confidences)} bboxes")
     return pred
 
 
 def filter_k_by(
     pred: PredictOutput[T], k: int = 0, by: str = "Area"
 ) -> PredictOutput[T]:
+    print(f"[DEBUG] filter_k_by: mode={by}, k={k}")
     if by == "Area":
         return filter_k_largest(pred, k)
     if by == "Confidence":

--- a/modules/adetailer/vendor_adetailer/mediapipe.py
+++ b/modules/adetailer/vendor_adetailer/mediapipe.py
@@ -47,13 +47,16 @@ def mediapipe_face_detection(
         pred = face_detector.process(img_array)
 
     if pred.detections is None:
+        print("[DEBUG] mediapipe_face_detection: detections empty")
         return PredictOutput()
+
+    print(f"[DEBUG] mediapipe_face_detection: {len(pred.detections)} detections")
 
     preview_array = img_array.copy()
 
     bboxes = []
     confidences = []
-    for detection in pred.detections:
+    for i, detection in enumerate(pred.detections):
         draw_util.draw_detection(preview_array, detection)
 
         bbox = detection.location_data.relative_bounding_box
@@ -63,6 +66,9 @@ def mediapipe_face_detection(
         h = bbox.height * img_height
         x2 = x1 + w
         y2 = y1 + h
+
+        area = (x2 - x1) * (y2 - y1)
+        print(f"[DEBUG] detection {i} bbox area: {area}")
 
         confidences.append(detection.score)
         bboxes.append([x1, y1, x2, y2])
@@ -93,19 +99,28 @@ def mediapipe_face_mesh(
         pred = face_mesh.process(arr)
 
         if pred.multi_face_landmarks is None:
+            print("[DEBUG] mediapipe_face_mesh: multi_face_landmarks empty")
             return PredictOutput()
+
+        print(
+            f"[DEBUG] mediapipe_face_mesh: {len(pred.multi_face_landmarks)} faces"
+        )
 
         preview = arr.copy()
         masks = []
         confidences = []
 
-        for landmarks in pred.multi_face_landmarks:
+        for i, landmarks in enumerate(pred.multi_face_landmarks):
             draw_util.draw_landmarks(
                 image=preview,
                 landmark_list=landmarks,
                 connections=mp_face_mesh.FACEMESH_TESSELATION,
                 landmark_drawing_spec=None,
                 connection_drawing_spec=drawing_styles.get_default_face_mesh_tesselation_style(),
+            )
+
+            print(
+                f"[DEBUG] face {i}: {len(landmarks.landmark)} landmark points"
             )
 
             points = np.array(
@@ -116,6 +131,8 @@ def mediapipe_face_mesh(
             mask = Image.new("L", image.size, "black")
             draw = ImageDraw.Draw(mask)
             draw.polygon(outline, fill="white")
+            mask_area = int(np.count_nonzero(np.array(mask)))
+            print(f"[DEBUG] face {i} mask area: {mask_area}")
             masks.append(mask)
             confidences.append(1.0)  # Confidence is unknown
 
@@ -145,13 +162,22 @@ def mediapipe_face_mesh_eyes_only(
         pred = face_mesh.process(arr)
 
         if pred.multi_face_landmarks is None:
+            print("[DEBUG] mediapipe_face_mesh_eyes_only: multi_face_landmarks empty")
             return PredictOutput()
+
+        print(
+            f"[DEBUG] mediapipe_face_mesh_eyes_only: {len(pred.multi_face_landmarks)} faces"
+        )
 
         preview = image.copy()
         masks = []
         confidences = []
 
-        for landmarks in pred.multi_face_landmarks:
+        for i, landmarks in enumerate(pred.multi_face_landmarks):
+            print(
+                f"[DEBUG] face {i}: {len(landmarks.landmark)} landmark points"
+            )
+
             points = np.array(
                 [[land.x * w, land.y * h] for land in landmarks.landmark], dtype=int
             )
@@ -164,6 +190,8 @@ def mediapipe_face_mesh_eyes_only(
             draw = ImageDraw.Draw(mask)
             for outline in (left_outline, right_outline):
                 draw.polygon(outline, fill="white")
+            mask_area = int(np.count_nonzero(np.array(mask)))
+            print(f"[DEBUG] face {i} mask area: {mask_area}")
             masks.append(mask)
             confidences.append(1.0)  # Confidence is unknown
 


### PR DESCRIPTION
## Summary
- log detections and mask sizes in mediapipe helpers
- report detailed filtering information in `filter_by_ratio` and `filter_k_by`

## Testing
- `pip install numpy opencv-python-headless pillow pydantic huggingface_hub rich pytest --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f4bdae34832b9c9e7f140766ad6e