### PR TITLE
Fix ADetailer image output

### DIFF
--- a/modules/adetailer/adetailer.py
+++ b/modules/adetailer/adetailer.py
@@ -108,6 +108,15 @@ def _apply_adetailer_single(image: Image.Image, model_name: str, tab_idx: int | 
     return image
 
 
+def _validate_image_output(image: Image.Image) -> Image.Image:
+    """Ensure the output is a valid RGB PIL image."""
+    if not isinstance(image, Image.Image):
+        raise ValueError("Output is not a valid PIL.Image object.")
+    if image.mode != "RGB":
+        image = image.convert("RGB")
+    return image
+
+
 def apply_adetailer_multi(image: Image.Image | np.ndarray, params: Optional[dict] = None) -> Image.Image | np.ndarray:
     """Apply ADetailer for all enabled tabs."""
     if not config.default_adetailer_enable:
@@ -134,6 +143,7 @@ def apply_adetailer_multi(image: Image.Image | np.ndarray, params: Optional[dict
             pil_img = _apply_adetailer_single(pil_img, config.default_adetailer_model, tab_idx=i)
     except Exception as e:  # pragma: no cover - best effort
         print(f"[ADetailer] failed: {e}")
+    pil_img = _validate_image_output(pil_img)
     if return_np:
         return np.array(pil_img)
     return pil_img

--- a/tests/test_adetailer.py
+++ b/tests/test_adetailer.py
@@ -27,6 +27,17 @@ class TestADetailerDownload(unittest.TestCase):
         img = Image.new('RGB', (10, 10))
         result = apply_adetailer_multi(img)
         self.assertEqual(result.size, (10, 10))
+        self.assertIsInstance(result, Image.Image)
+        self.assertEqual(result.mode, 'RGB')
+
+    def test_validate_image_output(self):
+        from modules.adetailer.adetailer import _validate_image_output
+        from PIL import Image
+
+        img = Image.new('L', (5, 5))
+        validated = _validate_image_output(img)
+        self.assertIsInstance(validated, Image.Image)
+        self.assertEqual(validated.mode, 'RGB')
 
     def test_refine_mask_region(self):
         from modules.adetailer.adetailer import _refine_mask_region


### PR DESCRIPTION
## Summary
- validate image type and mode after running ADetailer
- add new unit tests for output validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685613f38ef8832b8d50fc13f919f5f2